### PR TITLE
Fix/lattice 1637 remove distinct from entity query

### DIFF
--- a/src/main/java/com/openlattice/data/storage/MetadataOption.java
+++ b/src/main/java/com/openlattice/data/storage/MetadataOption.java
@@ -30,6 +30,5 @@ public enum MetadataOption {
     LAST_INDEX,
     LAST_LINK,
     LAST_WRITE,
-    LINKING_ID,
     VERSION
 }

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -330,7 +330,7 @@ class PostgresEntityDataQueryService(
             val updatedEntityCount = entitySetPreparedStatement.executeBatch().sum()
             preparedStatements.values.forEach(PreparedStatement::close)
             entitySetPreparedStatement.close()
-            checkState( updatedEntityCount >=  entities.size , "Updated entity metadata count mismatch")
+            checkState( updatedEntityCount == entities.size , "Updated entity metadata count mismatch")
 
             logger.debug("Updated $updatedEntityCount entities and $updatedPropertyCounts properties")
 

--- a/src/test/kotlin/com/openlattice/data/PostgresLinkedEntityDataQueryServiceTest.kt
+++ b/src/test/kotlin/com/openlattice/data/PostgresLinkedEntityDataQueryServiceTest.kt
@@ -149,6 +149,57 @@ class PostgresLinkedEntityDataQueryServiceTest {
     }
 
     @Test
+    fun testLinkingEntitySetVersionQuery() {
+        val entitySetId = UUID.fromString("ed5716db-830b-41b7-9905-24fa82761ace")
+
+        val propertyTypeMap = mapOf(
+                Pair(UUID.fromString("c270d705-3616-4abc-b16e-f891e264b784"), DataTables.quote("im.PersonNickName")),
+                Pair(UUID.fromString("7b038634-a0b4-4ce1-a04f-85d1775937aa"), DataTables.quote("nc.PersonSurName")),
+                Pair(UUID.fromString("8293b7f3-d89d-44f5-bec2-6397a4c5af8b"), DataTables.quote("nc.PersonHairColorText")),
+                Pair(UUID.fromString("5260cfbd-bfa4-40c1-ade5-cd83cc9f99b2"), DataTables.quote("nc.SubjectIdentification")),
+                Pair(UUID.fromString("e9a0b4dc-5298-47c1-8837-20af172379a5"), DataTables.quote("nc.PersonGivenName")),
+                Pair(UUID.fromString("d0935a7e-efd3-4903-b673-0869ef527dea"), DataTables.quote("nc.PersonMiddleName")),
+                Pair(UUID.fromString("45aa6695-a7e7-46b6-96bd-782e6aa9ac13"), DataTables.quote("publicsafety.mugshot")),
+                Pair(UUID.fromString("1e6ff0f0-0545-4368-b878-677823459e57"), DataTables.quote("nc.PersonBirthDate")),
+                Pair(UUID.fromString("ac37e344-62da-4b50-b608-0618a923a92d"), DataTables.quote("nc.PersonEyeColorText")),
+                Pair(UUID.fromString("481f59e4-e146-4963-a837-4f4e514df8b7"), DataTables.quote("nc.SSN")),
+                Pair(UUID.fromString("d9a90e01-9670-46e8-b142-6d0c4871f633"), DataTables.quote("j.SentenceRegisterSexOffenderIndicator")),
+                Pair(UUID.fromString("d3f3f3de-dc1b-40da-9076-683ddbfeb4d8"), DataTables.quote("nc.PersonSuffix")),
+                Pair(UUID.fromString("f0a6a588-aee7-49a2-8f8e-e5209731da30"), DataTables.quote("nc.PersonHeightMeasure")),
+                Pair(UUID.fromString("fa00bfdb-98ec-487a-b62f-f6614e4c921b"), DataTables.quote("criminaljustice.persontype")),
+                Pair(UUID.fromString("5ea6e8d5-93bb-47cf-b054-9faaeb05fb27"), DataTables.quote("person.stateidstate")),
+                Pair(UUID.fromString("6ec154f8-a4a1-4df2-8c57-d98cbac1478e"), DataTables.quote("nc.PersonSex")),
+                Pair(UUID.fromString("cf4598e7-5bbe-49f7-8935-4b1a692f6111"), DataTables.quote("nc.PersonBirthPlace")),
+                Pair(UUID.fromString("32eba813-7d20-4be1-bc1a-717f99917a5e"), DataTables.quote("housing.notes")),
+                Pair(UUID.fromString("c7d2c503-651d-483f-8c17-72358bcfc5cc"), DataTables.quote("justice.xref")),
+                Pair(UUID.fromString("f950d05a-f4f2-451b-8c6d-56e78bba8b42"), DataTables.quote("nc.PersonRace")),
+                Pair(UUID.fromString("314d2bfd-e50e-4965-b2eb-422742fa265c"), DataTables.quote("housing.updatedat")),
+                Pair(UUID.fromString("1407ac70-ea63-4879-aca4-6722034f0cda"), DataTables.quote("nc.PersonEthnicity"))
+        )
+        val entityKeyIds = sequenceOf(
+                "73170000-0000-0000-8000-0000000004a9",
+                "4d9b0000-0000-0000-8000-00000000005d"
+        )
+                .map(UUID::fromString)
+                .toSet()
+        val version = Instant.now().minusMillis(1382400000).toEpochMilli()
+        logger.info(
+                "Entity set query: {}",
+                selectEntitySetWithPropertyTypesAndVersionSql(
+                        mapOf( entitySetId to Optional.of(entityKeyIds)),
+                        propertyTypeMap,
+                        propertyTypeMap.keys,
+                        mapOf( entitySetId to propertyTypeMap.keys ),
+                        mapOf(),
+                        setOf(),
+                        version,
+                        true,
+                        propertyTypeMap.keys.map { it to (it==UUID.fromString("45aa6695-a7e7-46b6-96bd-782e6aa9ac13")) }.toMap()
+                )
+        )
+    }
+
+    @Test
     fun testEmptySelectEntitySets() {
         logger.info(selectEntitySetWithCurrentVersionOfPropertyTypes(mapOf(), mapOf(), listOf(), mapOf(), mapOf(), setOf(), false, mapOf()))
     }
@@ -159,28 +210,28 @@ class PostgresLinkedEntityDataQueryServiceTest {
         val entitySetId = UUID.fromString("ed5716db-830b-41b7-9905-24fa82761ace")
 
         val propertyTypeMap = mapOf(
-                Pair(UUID.fromString("c270d705-3616-4abc-b16e-f891e264b784"), "im.PersonNickName"),
-                Pair(UUID.fromString("7b038634-a0b4-4ce1-a04f-85d1775937aa"), "nc.PersonSurName"),
-                Pair(UUID.fromString("8293b7f3-d89d-44f5-bec2-6397a4c5af8b"), "nc.PersonHairColorText"),
-                Pair(UUID.fromString("5260cfbd-bfa4-40c1-ade5-cd83cc9f99b2"), "nc.SubjectIdentification"),
-                Pair(UUID.fromString("e9a0b4dc-5298-47c1-8837-20af172379a5"), "nc.PersonGivenName"),
-                Pair(UUID.fromString("d0935a7e-efd3-4903-b673-0869ef527dea"), "nc.PersonMiddleName"),
-                Pair(UUID.fromString("45aa6695-a7e7-46b6-96bd-782e6aa9ac13"), "publicsafety.mugshot"),
-                Pair(UUID.fromString("1e6ff0f0-0545-4368-b878-677823459e57"), "nc.PersonBirthDate"),
-                Pair(UUID.fromString("ac37e344-62da-4b50-b608-0618a923a92d"), "nc.PersonEyeColorText"),
-                Pair(UUID.fromString("481f59e4-e146-4963-a837-4f4e514df8b7"), "nc.SSN"),
-                Pair(UUID.fromString("d9a90e01-9670-46e8-b142-6d0c4871f633"), "j.SentenceRegisterSexOffenderIndicator"),
-                Pair(UUID.fromString("d3f3f3de-dc1b-40da-9076-683ddbfeb4d8"), "nc.PersonSuffix"),
-                Pair(UUID.fromString("f0a6a588-aee7-49a2-8f8e-e5209731da30"), "nc.PersonHeightMeasure"),
-                Pair(UUID.fromString("fa00bfdb-98ec-487a-b62f-f6614e4c921b"), "criminaljustice.persontype"),
-                Pair(UUID.fromString("5ea6e8d5-93bb-47cf-b054-9faaeb05fb27"), "person.stateidstate"),
-                Pair(UUID.fromString("6ec154f8-a4a1-4df2-8c57-d98cbac1478e"), "nc.PersonSex"),
-                Pair(UUID.fromString("cf4598e7-5bbe-49f7-8935-4b1a692f6111"), "nc.PersonBirthPlace"),
-                Pair(UUID.fromString("32eba813-7d20-4be1-bc1a-717f99917a5e"), "housing.notes"),
-                Pair(UUID.fromString("c7d2c503-651d-483f-8c17-72358bcfc5cc"), "justice.xref"),
-                Pair(UUID.fromString("f950d05a-f4f2-451b-8c6d-56e78bba8b42"), "nc.PersonRace"),
-                Pair(UUID.fromString("314d2bfd-e50e-4965-b2eb-422742fa265c"), "housing.updatedat"),
-                Pair(UUID.fromString("1407ac70-ea63-4879-aca4-6722034f0cda"), "nc.PersonEthnicity")
+                Pair(UUID.fromString("c270d705-3616-4abc-b16e-f891e264b784"), DataTables.quote("im.PersonNickName")),
+                Pair(UUID.fromString("7b038634-a0b4-4ce1-a04f-85d1775937aa"), DataTables.quote("nc.PersonSurName")),
+                Pair(UUID.fromString("8293b7f3-d89d-44f5-bec2-6397a4c5af8b"), DataTables.quote("nc.PersonHairColorText")),
+                Pair(UUID.fromString("5260cfbd-bfa4-40c1-ade5-cd83cc9f99b2"), DataTables.quote("nc.SubjectIdentification")),
+                Pair(UUID.fromString("e9a0b4dc-5298-47c1-8837-20af172379a5"), DataTables.quote("nc.PersonGivenName")),
+                Pair(UUID.fromString("d0935a7e-efd3-4903-b673-0869ef527dea"), DataTables.quote("nc.PersonMiddleName")),
+                Pair(UUID.fromString("45aa6695-a7e7-46b6-96bd-782e6aa9ac13"), DataTables.quote("publicsafety.mugshot")),
+                Pair(UUID.fromString("1e6ff0f0-0545-4368-b878-677823459e57"), DataTables.quote("nc.PersonBirthDate")),
+                Pair(UUID.fromString("ac37e344-62da-4b50-b608-0618a923a92d"), DataTables.quote("nc.PersonEyeColorText")),
+                Pair(UUID.fromString("481f59e4-e146-4963-a837-4f4e514df8b7"), DataTables.quote("nc.SSN")),
+                Pair(UUID.fromString("d9a90e01-9670-46e8-b142-6d0c4871f633"), DataTables.quote("j.SentenceRegisterSexOffenderIndicator")),
+                Pair(UUID.fromString("d3f3f3de-dc1b-40da-9076-683ddbfeb4d8"), DataTables.quote("nc.PersonSuffix")),
+                Pair(UUID.fromString("f0a6a588-aee7-49a2-8f8e-e5209731da30"), DataTables.quote("nc.PersonHeightMeasure")),
+                Pair(UUID.fromString("fa00bfdb-98ec-487a-b62f-f6614e4c921b"), DataTables.quote("criminaljustice.persontype")),
+                Pair(UUID.fromString("5ea6e8d5-93bb-47cf-b054-9faaeb05fb27"), DataTables.quote("person.stateidstate")),
+                Pair(UUID.fromString("6ec154f8-a4a1-4df2-8c57-d98cbac1478e"), DataTables.quote("nc.PersonSex")),
+                Pair(UUID.fromString("cf4598e7-5bbe-49f7-8935-4b1a692f6111"), DataTables.quote("nc.PersonBirthPlace")),
+                Pair(UUID.fromString("32eba813-7d20-4be1-bc1a-717f99917a5e"), DataTables.quote("housing.notes")),
+                Pair(UUID.fromString("c7d2c503-651d-483f-8c17-72358bcfc5cc"), DataTables.quote("justice.xref")),
+                Pair(UUID.fromString("f950d05a-f4f2-451b-8c6d-56e78bba8b42"), DataTables.quote("nc.PersonRace")),
+                Pair(UUID.fromString("314d2bfd-e50e-4965-b2eb-422742fa265c"), DataTables.quote("housing.updatedat")),
+                Pair(UUID.fromString("1407ac70-ea63-4879-aca4-6722034f0cda"), DataTables.quote("nc.PersonEthnicity"))
         );
         val entityKeyIds = sequenceOf(
                 "73170000-0000-0000-8000-0000000004a9",
@@ -235,7 +286,7 @@ class PostgresLinkedEntityDataQueryServiceTest {
     }
 
     @Test
-    fun testEntitySetQueryLinking() {
+    fun testLinkingEntitySetQuery() {
         val entitySetId = UUID.fromString("ed5716db-830b-41b7-9905-24fa82761ace")
 
         val propertyTypeMap = mapOf(


### PR DESCRIPTION
final query looks something like this (depending on selected props and linking ids):
SELECT linking_id,"nc.PersonSurName","nc.PersonGivenName" FROM (SELECT DISTINCT linking_id FROM entity_key_ids WHERE version > 0  AND linking_id IS NOT NULL  AND ( (entity_set_id = '91551726-afa2-4aee-8579-46cdfc610b97'  AND linking_id IN ('03fe0000-0000-0000-8000-000000000000','05e50000-0000-0000-8000-000000000000'))) ) as entity_key_ids LEFT JOIN (SELECT linking_id,  array_agg("nc.PersonSurName") as "nc.PersonSurName"  FROM "pt_7b038634-a0b4-4ce1-a04f-85d1775937aa" INNER JOIN (SELECT entity_set_id,id,linking_id FROM entity_key_ids) as linking_ids USING(entity_set_id,id)WHERE version > 0  AND linking_id IS NOT NULL  AND ( (entity_set_id = '91551726-afa2-4aee-8579-46cdfc610b97'  AND linking_id IN ('03fe0000-0000-0000-8000-000000000000','05e50000-0000-0000-8000-000000000000')))  GROUP BY (linking_id)) as "pt_7b038634-a0b4-4ce1-a04f-85d1775937aa"  USING (linking_id)
LEFT JOIN (SELECT linking_id,  array_agg("nc.PersonGivenName") as "nc.PersonGivenName"  FROM "pt_e9a0b4dc-5298-47c1-8837-20af172379a5" INNER JOIN (SELECT entity_set_id,id,linking_id FROM entity_key_ids) as linking_ids USING(entity_set_id,id)WHERE version > 0  AND linking_id IS NOT NULL  AND ( (entity_set_id = '91551726-afa2-4aee-8579-46cdfc610b97'  AND linking_id IN ('03fe0000-0000-0000-8000-000000000000','05e50000-0000-0000-8000-000000000000')))  GROUP BY (linking_id)) as "pt_e9a0b4dc-5298-47c1-8837-20af172379a5"  USING (linking_id)

Result of that is:
              linking_id              |                                                                                                                                         nc.PersonSurName
--------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 03fe0000-0000-0000-8000-000000000000 | {Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunatall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunatall,Tunatall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunstall,Tunsta
 05e50000-0000-0000-8000-000000000000 | {Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters,Walters}
(2 rows)

