### PR TITLE
if filtered neighbors search with no allowed edge entity sets, return…

### DIFF
--- a/src/main/java/com/openlattice/search/SearchService.java
+++ b/src/main/java/com/openlattice/search/SearchService.java
@@ -463,6 +463,10 @@ public class SearchService {
     public Map<UUID, List<NeighborEntityDetails>> executeLinkingEntityNeighborSearch(
             Set<UUID> linkedEntitySetIds,
             EntityNeighborsFilter filter ) {
+        if ( filter.getAssociationEntitySetIds().isPresent() && filter.getAssociationEntitySetIds().get().isEmpty() ) {
+            return ImmutableMap.of();
+        }
+        
         Set<UUID> linkingIds = filter.getEntityKeyIds();
 
         PostgresIterable<Pair<UUID, Set<UUID>>> entityKeyIdsByLinkingIds = getEntityKeyIdsByLinkingIds( linkingIds );
@@ -479,7 +483,7 @@ public class SearchService {
                         filter.getDstEntitySetIds(),
                         filter.getAssociationEntitySetIds() ) );
 
-        if(entityNeighbors.isEmpty()) {
+        if ( entityNeighbors.isEmpty() ) {
             return entityNeighbors;
         }
 
@@ -502,6 +506,10 @@ public class SearchService {
     public Map<UUID, List<NeighborEntityDetails>> executeEntityNeighborSearch(
             Set<UUID> entitySetIds,
             EntityNeighborsFilter filter ) {
+        if ( filter.getAssociationEntitySetIds().isPresent() && filter.getAssociationEntitySetIds().get().isEmpty() ) {
+            return ImmutableMap.of();
+        }
+
         Set<Principal> principals = Principals.getCurrentPrincipals();
 
         Set<UUID> entityKeyIds = filter.getEntityKeyIds();


### PR DESCRIPTION
… an empty map