### PR TITLE
Bugfix/multiplicity in entities

### DIFF
--- a/src/main/kotlin/com/openlattice/data/DataGraphService.kt
+++ b/src/main/kotlin/com/openlattice/data/DataGraphService.kt
@@ -339,14 +339,13 @@ open class DataGraphService(
             associations: Set<Association>,
             authorizedPropertiesByEntitySetId: Map<UUID, Map<UUID, PropertyType>>
     ): IntegrationResults? {
-        val entitiesByEntitySet = HashMap<UUID, MutableMap<String, Map<UUID, Set<Any>>>>()
-
+        val entitiesByEntitySet = HashMap<UUID, MutableMap<String, MutableMap<UUID, MutableSet<Any>>>>()
         for (entity in entities) {
             val entitiesToCreate = entitiesByEntitySet.getOrPut(entity.entitySetId) { mutableMapOf() }
-            val entityDetails = entitiesToCreate.getOrPut(entity.entityId) { entity.details }.toMutableMap()
+            val entityDetails = entitiesToCreate.getOrPut(entity.entityId) { entity.details }
             if(entityDetails !== entity.details) {
                 entity.details.forEach { propertyTypeId, values ->
-                    entityDetails.getOrPut(propertyTypeId){ mutableSetOf() }.toMutableSet().addAll( values )
+                    entityDetails.getOrPut(propertyTypeId){ mutableSetOf() }.addAll( values )
                 }
             }
         }

--- a/src/main/kotlin/com/openlattice/data/DataGraphService.kt
+++ b/src/main/kotlin/com/openlattice/data/DataGraphService.kt
@@ -341,7 +341,20 @@ open class DataGraphService(
 
         for (entity in entities) {
             val entitiesToCreate = entitiesByEntitySet.getOrPut(entity.entitySetId) { HashMap() }
-            entitiesToCreate[entity.entityId] = entity.details
+            if (entity.entityId in entitiesToCreate.keys) {
+                val mergedEntity = mutableMapOf<UUID, Set<Any>>()
+                mergedEntity.putAll(entity.details)
+                entitiesToCreate[entity.entityId]!!.forEach { k ->
+                    if (k.key in mergedEntity.keys) {
+                        mergedEntity.put(k.key,mergedEntity[k.key]!!.plus(k.value))
+                    } else {
+                        mergedEntity.put(k.key,k.value)
+                    }
+                }
+                entitiesToCreate[entity.entityId] = mergedEntity
+            } else {
+                entitiesToCreate[entity.entityId] = entity.details
+            }
         }
 
         entitiesByEntitySet

--- a/src/main/kotlin/com/openlattice/data/DataGraphService.kt
+++ b/src/main/kotlin/com/openlattice/data/DataGraphService.kt
@@ -340,20 +340,12 @@ open class DataGraphService(
         val entitiesByEntitySet = HashMap<UUID, MutableMap<String, Map<UUID, Set<Any>>>>()
 
         for (entity in entities) {
-            val entitiesToCreate = entitiesByEntitySet.getOrPut(entity.entitySetId) { HashMap() }
-            if (entity.entityId in entitiesToCreate.keys) {
-                val mergedEntity = mutableMapOf<UUID, Set<Any>>()
-                mergedEntity.putAll(entity.details)
-                entitiesToCreate[entity.entityId]!!.forEach { k ->
-                    if (k.key in mergedEntity.keys) {
-                        mergedEntity.put(k.key,mergedEntity[k.key]!!.plus(k.value))
-                    } else {
-                        mergedEntity.put(k.key,k.value)
-                    }
+            val entitiesToCreate = entitiesByEntitySet.getOrPut(entity.entitySetId) { mutableMapOf() }
+            val entityDetails = entitiesToCreate.getOrPut(entity.entityId) { entity.details }.toMutableMap()
+            if(entityDetails !== entity.details) {
+                entity.details.forEach { propertyTypeId, values ->
+                    entityDetails.getOrPut(propertyTypeId){ mutableSetOf() }.toMutableSet().addAll( values )
                 }
-                entitiesToCreate[entity.entityId] = mergedEntity
-            } else {
-                entitiesToCreate[entity.entityId] = entity.details
             }
         }
 


### PR DESCRIPTION
## Problem:

#### Input:

| ID | FirstName | LastName |
| --- | --- | --- |
| 123 | Ariana | Grande |
| 123 | Ari | Grande |

#### Expected output:

| nc.SubjectIdentification | nc.PersonGivenName | nc.PersonSurName |
| --- | --- | --- |
| 123 | [Ariana, Ari] | [Grande] |

#### Observed output:

| nc.SubjectIdentification | nc.PersonGivenName | nc.PersonSurName |
| --- | --- | --- |
| 123 | [Ari] | [Grande] |


## Detailed description of bug and fix:
The original data will be transformed into *entities* to pass to DataGraphService.integrateEntitiesAndAssociations() as:
```
entities:
    - key: 
        entitySetId: 0000
        entityId: 0000
      value:
        UUID(nc.PersonGivenName): "Ariana"
        UUID(nc.PersonSurName): "Grande"
        UUID(nc.SubjectIdentification): 123
    - key: 
        entitySetId: 0000
        entityId: 0000
      value:
        UUID(nc.PersonGivenName): "Ari"
        UUID(nc.PersonSurName): "Grande"
        UUID(nc.SubjectIdentification): 123
```

**Expected result**
```
entitiesToCreate:
    0000:
        UUID(nc.PersonGivenName): Set(Ariana, Ari)
        UUID(nc.PersonSurName): Set(Grande)
        UUID(nc.SubjectIdentification): Set(123)       
```

**What actually happens when looping over entities (depending on the order):**
Iteration 1:
```
entitiesToCreate:
    entityId:
        UUID(nc.PersonGivenName): Set(Ariana)
        UUID(nc.PersonSurName): Set(Grande)
        UUID(nc.SubjectIdentification): Set(123)       
```
Iteration 2:
```
entitiesToCreate:
    entityId:
        UUID(nc.PersonGivenName): Set(Ari) 
        UUID(nc.PersonSurName): Set(Grande)
        UUID(nc.SubjectIdentification): Set(123)       
```

In iteration 2, the original set is overwritten by `entitiesToCreate[entity.entityId] = entity.details`.  This fix checks whether the entityId already exists in the map, and creates a mergedEntity if so.


