### PR TITLE
Lattice 1725 s3 content type metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'checkstyle'
-    id 'com.github.spotbugs' version '1.6.3'
+    id 'com.github.spotbugs' version '1.6.6'
     id 'org.jetbrains.kotlin.jvm' version '1.3.10'
     id 'org.jetbrains.kotlin.plugin.spring' version '1.3.10'
     id 'org.jetbrains.dokka' version '0.9.17'
@@ -60,7 +60,7 @@ tasks.withType(Checkstyle) {
 }
 
 spotbugs {
-    toolVersion = '3.1.5'
+    toolVersion = '3.1.9'
 }
 
 tasks.withType(com.github.spotbugs.SpotBugsTask) {
@@ -81,11 +81,11 @@ dokka {
 
 
 dependencies {
-    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.7.1'
+    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.8.0'
     compileOnly 'net.jcip:jcip-annotations:1.0'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.9'
     testCompileOnly 'net.jcip:jcip-annotations:1.0'
-    testCompileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.3'
+    testCompileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.9'
     /*
      * SL4J
      */
@@ -108,6 +108,7 @@ dependencies {
     compile "org.apache.olingo:odata-commons-core:${odata_version}"
     compile "org.apache.olingo:odata-server-api:${odata_version}"
     compile "org.apache.olingo:odata-server-core:${odata_version}"
+    compile "org.apache.tika:tika-core:1.19.1"
 
     compile "org.xerial.snappy:snappy-java:${snappy_version}"
     compile "net.jpountz.lz4:lz4:${lz4_version}"

--- a/src/main/java/com/openlattice/postgres/JsonDeserializer.java
+++ b/src/main/java/com/openlattice/postgres/JsonDeserializer.java
@@ -12,6 +12,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.*;
 
+import kotlin.Pair;
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.edm.geo.Geospatial.Dimension;
 import org.apache.olingo.commons.api.edm.geo.Geospatial.Type;
@@ -68,12 +69,19 @@ public class JsonDeserializer {
              * Jackson binds to String
              */
             case Binary:
-                checkState( value instanceof String,
-                        "Expected string for property type %s with data %s, received %s",
+                checkState( value instanceof Pair<?, ?>,
+                        "Expected pair for property type %s with data %s, received %s",
                         dataType,
                         propertyTypeId,
                         value.getClass() );
-                return decoder.decode( (String) value );
+                Pair<?, ?> valuePair = (Pair<?, ?>) value;
+                checkState( valuePair.component1() instanceof String,
+                        "Expected string for content type, received %s",
+                        ( valuePair.component1() ).getClass() );
+                checkState( valuePair.component2() instanceof String,
+                        "Expected string for binary data, received %s",
+                        ( valuePair.component2() ).getClass() );
+                return new Pair( (String) valuePair.component1(), decoder.decode( (String) valuePair.component2() ) );
             case Date:
                 checkState( value instanceof String,
                         "Expected string for property type %s with data %s,  received %s",

--- a/src/main/kotlin/com/openlattice/data/storage/AwsBlobDataService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/AwsBlobDataService.kt
@@ -40,16 +40,11 @@ class AwsBlobDataService(
         return builder.build()
     }
 
-    override fun putObject(s3Key: String, data: ByteArray) {
+    override fun putObject(s3Key: String, data: ByteArray, contentType: String) {
         var metadata = ObjectMetadata()
         var dataInputStream = data.inputStream()
         metadata.contentLength = dataInputStream.available().toLong()
-        metadata.contentType = "image"
-        val tika = Tika()
-        val tikaMetadata = Metadata()
-        tika.detect(dataInputStream, tikaMetadata)
-        metadata.contentType = mediaType.getType() + mediaType.getSubtype()
-        */
+        metadata.contentType = contentType
         val putRequest = PutObjectRequest(datastoreConfiguration.bucketName, s3Key, dataInputStream, metadata)
         s3.putObject(putRequest)
 

--- a/src/main/kotlin/com/openlattice/data/storage/AwsBlobDataService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/AwsBlobDataService.kt
@@ -43,6 +43,11 @@ class AwsBlobDataService(
         var dataInputStream = data.inputStream()
         metadata.contentLength = dataInputStream.available().toLong()
         metadata.contentType = "image"
+        /*
+        Tika tika = new Tika()
+        MediaType mediaType = tika.detect(dataInputStream, ?)
+        metadata.contentType = mediaType.getType() + mediaType.getSubtype()
+        */
         val putRequest = PutObjectRequest(datastoreConfiguration.bucketName, s3Key, dataInputStream, metadata)
         s3.putObject(putRequest)
 

--- a/src/main/kotlin/com/openlattice/data/storage/AwsBlobDataService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/AwsBlobDataService.kt
@@ -13,6 +13,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.openlattice.datastore.configuration.DatastoreConfiguration
+import okhttp3.MediaType
+import org.apache.tika.Tika
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.net.URL
@@ -43,9 +45,9 @@ class AwsBlobDataService(
         var dataInputStream = data.inputStream()
         metadata.contentLength = dataInputStream.available().toLong()
         metadata.contentType = "image"
-        /*
-        Tika tika = new Tika()
-        MediaType mediaType = tika.detect(dataInputStream, ?)
+        val tika = Tika()
+        val tikaMetadata = Metadata()
+        tika.detect(dataInputStream, tikaMetadata)
         metadata.contentType = mediaType.getType() + mediaType.getSubtype()
         */
         val putRequest = PutObjectRequest(datastoreConfiguration.bucketName, s3Key, dataInputStream, metadata)

--- a/src/main/kotlin/com/openlattice/data/storage/ByteBlobDataManager.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/ByteBlobDataManager.kt
@@ -1,7 +1,7 @@
 package com.openlattice.data.storage
 
 interface ByteBlobDataManager {
-    fun putObject(s3Key: String, data: ByteArray)
+    fun putObject(s3Key: String, data: ByteArray, contentType: String)
 
     fun deleteObject(s3Key: String)
 

--- a/src/main/kotlin/com/openlattice/data/storage/LocalBlobDataService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/LocalBlobDataService.kt
@@ -10,7 +10,7 @@ private val logger = LoggerFactory.getLogger(LocalBlobDataService::class.java)
 @Service
 class LocalBlobDataService(private val hds: HikariDataSource) : ByteBlobDataManager {
 
-    override fun putObject(s3Key: String, data: ByteArray) {
+    override fun putObject(s3Key: String, data: ByteArray, contentType: String) {
         insertEntity(s3Key, data)
     }
 

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -300,11 +300,12 @@ class PostgresEntityDataQueryService(
                                     //Binary data types get stored in S3 bucket
                                     if (datatypes[propertyTypeId] == EdmPrimitiveTypeKind.Binary) {
                                         //store data in S3 bucket
-                                        val propertyHash = PostgresDataHasher.hashObjectToHex(it, EdmPrimitiveTypeKind.Binary)
+                                        val pair = it as Pair<String, ByteArray>
+                                        val propertyHash = PostgresDataHasher.hashObjectToHex(pair.second, EdmPrimitiveTypeKind.Binary)
 
                                         //store entity set id/entity key id/property type id/property hash as key in S3
                                         val s3Key = entitySetId.toString() + "/" + entityKeyId.toString() + "/" + propertyTypeId.toString() + "/" + propertyHash
-                                        byteBlobDataManager.putObject(s3Key, it as ByteArray)
+                                        byteBlobDataManager.putObject(s3Key, pair.second, pair.first)
 
                                         //store S3 key to data in postgres as property value
                                         ps?.setBytes(2, PostgresDataHasher.hashObject(s3Key, EdmPrimitiveTypeKind.String))


### PR DESCRIPTION
NOT READY FOR MERGE

The idea here is that when writing an entity with a binary property, we will expect the data to be passed to the backend as a Pair<content-type as a string, binary data>. This will allow the backend to know which content-type belongs with which binary property in the case that multiple binary properties are contained in the same entity.