### PR TITLE
On reindexing for updates, pass full entities to elasticsearch and do…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,7 @@ eclipse {
 compileKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs = ['-Xjvm-default=compatibility']
     }
 }
 compileTestKotlin {

--- a/src/main/java/com/openlattice/neuron/pods/NeuronPod.java
+++ b/src/main/java/com/openlattice/neuron/pods/NeuronPod.java
@@ -59,7 +59,9 @@ import com.openlattice.linking.graph.PostgresLinkingQueryService;
 import com.openlattice.neuron.Neuron;
 import com.openlattice.postgres.PostgresTableManager;
 import com.zaxxer.hikari.HikariDataSource;
+
 import javax.inject.Inject;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -135,7 +137,8 @@ public class NeuronPod {
         return new HazelcastEntityDatastore(
                 idService(),
                 postgresDataManager(),
-                dataQueryService()
+                dataQueryService(),
+                dataModelService()
         );
     }
 


### PR DESCRIPTION
…n't load entities if there are too many to be indexed