### PR TITLE
Multiple fixes for integrations and s3 storage

### DIFF
--- a/src/main/java/com/openlattice/postgres/JsonDeserializer.java
+++ b/src/main/java/com/openlattice/postgres/JsonDeserializer.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import com.openlattice.data.storage.BinaryDataWithContentType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -109,7 +110,7 @@ public class JsonDeserializer {
                 checkState( data instanceof String,
                         "Expected string for binary data, received %s",
                         data.getClass() );
-                return new Pair<>( (String) contentType, decoder.decode( (String) data ) );
+                return new BinaryDataWithContentType( (String) contentType, decoder.decode( (String) data ) );
             //                    logger.error("Received single value for binary data type, when expecting content type");
             case Date:
                 checkState( value instanceof String,

--- a/src/main/kotlin/com/openlattice/data/storage/AwsDataSinkService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/AwsDataSinkService.kt
@@ -13,90 +13,45 @@ import org.springframework.stereotype.Service
 import java.net.URL
 import java.sql.PreparedStatement
 import java.util.*
+import javax.annotation.PostConstruct
 import javax.inject.Inject
 
 private val logger = LoggerFactory.getLogger(AwsDataSinkService::class.java)
 
-@Service
-class AwsDataSinkService {
-    @Inject
-    lateinit var byteBlobDataManager: ByteBlobDataManager
-    @Inject
-    lateinit var hds: HikariDataSource
 
-    fun generatePresignedUrls(entities: List<S3EntityData>, authorizedPropertyTypes: Map<UUID, Map<UUID, PropertyType>>): List<String> {
-        val postgresData = mutableMapOf<S3EntityData, String>()
+class AwsDataSinkService(
+        private val byteBlobDataManager: ByteBlobDataManager,
+        private val hds: HikariDataSource
+) {
+    private val dqs = PostgresEntityDataQueryService(hds, byteBlobDataManager)
+
+    fun generatePresignedUrls(
+            entities: List<S3EntityData>, authorizedPropertyTypes: Map<UUID, Map<UUID, PropertyType>>
+    ): List<String> {
+        val data = mutableMapOf<UUID, MutableMap<UUID, MutableMap<UUID, MutableSet<Any>>>>()
         val urls = Lists.newArrayList<String>()
         val expirationTime = Date()
         val timeToLive = expirationTime.time + 6000000
         expirationTime.time = timeToLive
         entities.forEach {
-            val key = it.entitySetId.toString() + "/" + it.entityKeyId.toString() + "/" + it.propertyTypeId.toString() + "/" + it.propertyHash
-            val url = byteBlobDataManager.getPresignedUrl(key, expirationTime, HttpMethod.PUT, Optional.empty())
-            postgresData[it] = key
-            urls.add(url.toString())
+            val key = "${it.entitySetId}/${it.entityKeyId}/${it.propertyTypeId}/${it.propertyHash}"
+            val url = byteBlobDataManager
+                    .getPresignedUrl(key, expirationTime, HttpMethod.PUT, Optional.empty())
+                    .toString()
+
+            data
+                    .getOrPut(it.entitySetId) { mutableMapOf() }
+                    .getOrPut(it.entityKeyId) { mutableMapOf() }
+                    .getOrPut(it.propertyTypeId) { mutableSetOf() }
+                    .add(key)
+
+            urls.add(url)
         }
         //write s3Keys to postgres
-        postgresData.forEach {
-            writeToPostgres(it, authorizedPropertyTypes[it.key.entitySetId]!!)
+        data.forEach { entitySetId, data ->
+            dqs.upsertEntities(entitySetId, data, authorizedPropertyTypes.getValue(entitySetId), true)
         }
+
         return urls
     }
-
-    private fun writeToPostgres(data: Map.Entry<S3EntityData, String>, authorizedPropertyTypes: Map<UUID, PropertyType>) {
-        val connection = hds.connection
-        connection.use {
-            val version = System.currentTimeMillis()
-            val entitySetId = data.key.entitySetId
-            val entitySetPreparedStatement = connection.prepareStatement(upsertEntity(entitySetId, version))
-            val datatypes = authorizedPropertyTypes.map {
-                it.key to it.value.datatype
-            }.toMap()
-            val preparedStatements = authorizedPropertyTypes
-                    .map {
-                        it.key to connection.prepareStatement(
-                                upsertPropertyValues(
-                                        entitySetId, it.key, it.value.type.fullQualifiedNameAsString, version
-                                )
-                        )
-                    }
-                    .toMap()
-
-            entitySetPreparedStatement.setObject(1, entitySetId)
-            entitySetPreparedStatement.addBatch()
-
-            val entityKeyId = data.key.entityKeyId
-            val propertyTypeId = data.key.propertyTypeId
-            val propertyHash = data.key.propertyHash
-            val s3Key = "$entitySetId/$entityKeyId/$propertyTypeId/$propertyHash"
-
-            if (s3Key == null) {
-                logger.error(
-                        "Encountered null property value of type {} for entity set {} with entity key id {}",
-                        propertyTypeId, entitySetId, entityKeyId
-                )
-            } else {
-                val hashAsBytes = ByteArray(propertyHash.length / 2) { propertyHash.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
-                val ps = preparedStatements[propertyTypeId]
-                ps?.setObject(1, entityKeyId)
-                ps?.setBytes(2, hashAsBytes)
-                ps?.setObject(3, s3Key)
-                ps?.addBatch()
-                if (ps == null) {
-                    logger.warn(
-                            "Skipping unauthorized property in entity $entityKeyId from entity set $entitySetId"
-                    )
-                }
-            }
-
-            val updatedPropertyCounts = preparedStatements.values.map { it.executeBatch() }.sumBy { it.sum() }
-            val updatedEntityCount = entitySetPreparedStatement.executeBatch().sum()
-            preparedStatements.values.forEach(PreparedStatement::close)
-            entitySetPreparedStatement.close()
-
-            logger.debug("Updated $updatedEntityCount entities and $updatedPropertyCounts properties")
-        }
-
-    }
-
 }

--- a/src/main/kotlin/com/openlattice/data/storage/BinaryDataWithContentType.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/BinaryDataWithContentType.kt
@@ -1,0 +1,23 @@
+package com.openlattice.data.storage
+
+/**
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+data class BinaryDataWithContentType(val contentType: String, val data: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BinaryDataWithContentType) return false
+
+        if (contentType != other.contentType) return false
+        if (!data.contentEquals(other.data)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = contentType.hashCode()
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+}

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -373,9 +373,33 @@ class PostgresEntityDataQueryService(
             entitySetId: UUID, entities: Map<UUID, Map<UUID, Set<Any>>>,
             authorizedPropertyTypes: Map<UUID, PropertyType>
     ): Int {
+        return upsertEntities(entitySetId, entities, authorizedPropertyTypes)
+    }
+
+    fun upsertEntities(
+            entitySetId: UUID, entities: Map<UUID, Map<UUID, Set<Any>>>,
+            authorizedPropertyTypes: Map<UUID, PropertyType>,
+            awsPassthrough: Boolean
+    ): Int {
+        val version = System.currentTimeMillis()
+
+        //Update the versions of all entities.
+        val updatedEntityCount = hds.connection.use { connection ->
+            connection.autoCommit = false
+            return@use connection.createStatement().use { updateEntities ->
+                val idsClause = buildEntityKeyIdsClause(entities.keys)
+                updateEntities.execute(lockEntities(entitySetId, idsClause, version))
+                val updateCount = updateEntities.executeUpdate(upsertEntities(entitySetId, idsClause, version))
+                connection.commit()
+                connection.autoCommit = true
+                return@use updateCount
+            }
+        }
+
+        //Now upsert all the properties
         hds.connection.use { connection ->
-            val version = System.currentTimeMillis()
-            val entitySetPreparedStatement = connection.prepareStatement(upsertEntity(entitySetId, version))
+
+            //            val entitySetPreparedStatement = connection.prepareStatement(upsertEntity(entitySetId, version))
             val dataTypes = authorizedPropertyTypes.mapValues { (_, propertyType) ->
                 propertyType.datatype
             }
@@ -392,21 +416,16 @@ class PostgresEntityDataQueryService(
                         )
                     }
 
-
-
             entities.forEach { entity ->
-                entitySetPreparedStatement.setObject(1, entity.key)
-                entitySetPreparedStatement.addBatch()
-
                 val entityKeyId = entity.key
                 val entityData = asMap(JsonDeserializer
                                                .validateFormatAndNormalize(entity.value, dataTypes)
                                                { "Entity set $entitySetId with entity key id $entityKeyId" })
 
                 entityData.forEach { (propertyTypeId, values) ->
-                    val upsertStatements = preparedStatements[propertyTypeId]
+                    val upserts = preparedStatements[propertyTypeId]
 
-                    if (upsertStatements == null) {
+                    if (upserts == null) {
                         logger.warn(
                                 "Not inserting unauthorized property in entity {} from entity set {}",
                                 entityKeyId,
@@ -414,31 +433,37 @@ class PostgresEntityDataQueryService(
                         )
                     } else {
                         values.forEach { value ->
-                            val ps = upsertStatements
-
                             //Binary data types get stored in S3 bucket
                             val (propertyHash, insertValue) =
                                     if (dataTypes[propertyTypeId] == EdmPrimitiveTypeKind.Binary) {
-                                        //store data in S3 bucket
-                                        val pair = value as Pair<String, ByteArray>
+                                        if (awsPassthrough) {
+                                            //Data is being stored in AWS directly the value will be the url fragment
+                                            //of where the data will be stored in AWS.
+                                            PostgresDataHasher.hashObject(value, EdmPrimitiveTypeKind.String) to value
+                                        } else {
+                                            //Data is expected to be of a specific type so that it can be stored in
+                                            //s3 bucket
 
-                                        val digest = PostgresDataHasher.hashObjectToHex(
-                                                pair.second, EdmPrimitiveTypeKind.Binary
-                                        )
-                                        //store entity set id/entity key id/property type id/property hash as key in S3
-                                        val s3Key = "$entitySetId/$entityKeyId/$propertyTypeId/$digest"
-                                        byteBlobDataManager.putObject(s3Key, pair.second, pair.first)
-                                        PostgresDataHasher.hashObject(s3Key, EdmPrimitiveTypeKind.String) to s3Key
+                                            val binaryData = value as BinaryDataWithContentType
+
+                                            val digest = PostgresDataHasher
+                                                    .hashObjectToHex(binaryData.data, EdmPrimitiveTypeKind.Binary)
+                                            //store entity set id/entity key id/property type id/property hash as key in S3
+                                            val s3Key = "$entitySetId/$entityKeyId/$propertyTypeId/$digest"
+                                            byteBlobDataManager
+                                                    .putObject(s3Key, binaryData.data, binaryData.contentType)
+                                            PostgresDataHasher
+                                                    .hashObject(s3Key, EdmPrimitiveTypeKind.String) to s3Key
+                                        }
                                     } else {
                                         PostgresDataHasher.hashObject(value, dataTypes[propertyTypeId]) to value
                                     }
 
-                            ps.setObject(1, entityKeyId)
-                            ps.setBytes(2, propertyHash)
-                            ps.setObject(3, insertValue)
+                            upserts.setObject(1, entityKeyId)
+                            upserts.setBytes(2, propertyHash)
+                            upserts.setObject(3, insertValue)
 
-
-                            ps.addBatch()
+                            upserts.addBatch()
                         }
                     }
                 }
@@ -447,11 +472,8 @@ class PostgresEntityDataQueryService(
             //In case we want to do validation
             val updatedPropertyCounts = preparedStatements.values.map { it.executeBatch() }.sumBy { it.sum() }
 
-            val updatedEntityCount = entitySetPreparedStatement.executeBatch().sum()
-
             preparedStatements.values.forEach { it.close() }
 
-            entitySetPreparedStatement.close()
             checkState(updatedEntityCount == entities.size, "Updated entity metadata count mismatch")
 
             logger.debug("Updated $updatedEntityCount entities and $updatedPropertyCounts properties")
@@ -805,6 +827,21 @@ fun deleteEntityKeys(entitySetId: UUID): String {
 
 fun deleteEntitySetEntityKeys(entitySetId: UUID): String {
     return "DELETE FROM ${IDS.name} WHERE ${ENTITY_SET_ID.name} = '$entitySetId' "
+}
+
+fun buildEntityKeyIdsClause(entityKeyIds: Set<UUID>): String {
+    return entityKeyIds.joinToString(",") { "'$it'" }
+}
+
+fun lockEntities(entitySetId: UUID, idsClause: String, version: Long): String {
+    return "SELECT 1 FOR UPDATE WHERE ${ENTITY_SET_ID.name} = '$entitySetId' AND ${ID_VALUE.name} = IN ($idsClause)"
+}
+
+fun upsertEntities(entitySetId: UUID, idsClause: String, version: Long): String {
+    return "UPDATE ${IDS.name} SET versions = ${VERSIONS.name} || ARRAY[$version], ${LAST_WRITE.name} = now(), " +
+            "${VERSION.name} = CASE WHEN abs(${IDS.name}.${VERSION.name}) < $version THEN $version " +
+            "ELSE ${IDS.name}.${VERSION.name} END " +
+            "WHERE ${ENTITY_SET_ID.name} = '$entitySetId' AND ${ID_VALUE.name} = IN ($idsClause)"
 }
 
 fun upsertEntity(entitySetId: UUID, version: Long): String {

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -398,8 +398,7 @@ class PostgresEntityDataQueryService(
 
         //Now upsert all the properties
         hds.connection.use { connection ->
-
-            //            val entitySetPreparedStatement = connection.prepareStatement(upsertEntity(entitySetId, version))
+            
             val dataTypes = authorizedPropertyTypes.mapValues { (_, propertyType) ->
                 propertyType.datatype
             }


### PR DESCRIPTION
- Clean up how objects are passed from JsonDeserializer to data query service
- Consolidate repeated code in AwsSinkService
- Fix bug in AwsDataSink service that was using entity set id as entity key id
- Improve performance for updating versions during updates as well as use SELECT FOR SHARE to avoid deadlocks.