### PR TITLE
Warn instead of fail.

### DIFF
--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -531,7 +531,10 @@ class PostgresEntityDataQueryService(
             }
         }.sum()
 
-        checkState(updatedEntityCount == entities.size, "Updated entity metadata count mismatch")
+        if( updatedEntityCount != entities.size ) {
+            logger.warn("Update $updatedEntityCount entities. Expect to update ${entities.size}.")
+            logger.warn("Entity key ids: {}", entities.keys)
+        }
 
         logger.debug("Updated $updatedEntityCount entities and $updatedPropertyCounts properties")
 


### PR DESCRIPTION
Kim is seeing this when integrating. It seems very strange-- the only case I can see causing this are that the entity_key_id hasn't been created yet, but that shouldn't be possible.