### PR TITLE
update EPs that are readonly abstractEPs to use the direct type

### DIFF
--- a/src/main/java/com/openlattice/datastore/services/EdmService.java
+++ b/src/main/java/com/openlattice/datastore/services/EdmService.java
@@ -684,19 +684,16 @@ public class EdmService implements EdmManager {
     @Override
     public Map<UUID, PropertyType> getPropertyTypesForEntitySet( UUID entitySetId ) {
 
-        Optional<UUID> maybeEtId = (Optional<UUID>) entitySets.executeOnKey( entitySetId, new GetEntityTypeFromEntitySetEntryProcessor() );
-        if ( maybeEtId.isEmpty() ) {
+        UUID maybeEtId = (UUID) entitySets.executeOnKey( entitySetId, new GetEntityTypeFromEntitySetEntryProcessor());
+        if ( maybeEtId == null ) {
             throw new ResourceNotFoundException( "Entity set " + entitySetId.toString() + " does not exist." );
         }
-
-        UUID entityTypeId = maybeEtId.get();
-        
-        Optional<Set<UUID>> maybeEtProps = (Optional<Set<UUID>>) entityTypes.executeOnKey( entityTypeId, new GetPropertiesFromEntityTypeEntryProcessor() );
-        if ( maybeEtProps.isEmpty() ) {
-            throw new ResourceNotFoundException( "Entity type " + entityTypeId.toString() + " does not exist." );
+        Set<UUID> maybeEtProps = (Set<UUID>) entityTypes.executeOnKey( maybeEtId, new GetPropertiesFromEntityTypeEntryProcessor());
+        if ( maybeEtProps == null ) {
+            throw new ResourceNotFoundException( "Entity type " + maybeEtId.toString() + " does not exist." );
         }
 
-        return propertyTypes.getAll( maybeEtProps.get() );
+        return propertyTypes.getAll( maybeEtProps );
     }
 
     @Override

--- a/src/main/kotlin/com/openlattice/assembler/processors/IsAssemblyInitializedEntryProcessor.kt
+++ b/src/main/kotlin/com/openlattice/assembler/processors/IsAssemblyInitializedEntryProcessor.kt
@@ -1,11 +1,10 @@
 package com.openlattice.assembler.processors
 
-import com.hazelcast.core.ReadOnly
-import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor
 import com.openlattice.assembler.OrganizationAssembly
+import com.openlattice.rhizome.hazelcast.entryprocessors.AbstractReadOnlyRhizomeEntryProcessor
 import java.util.*
 
-class IsAssemblyInitializedEntryProcessor : AbstractRhizomeEntryProcessor<UUID, OrganizationAssembly, Boolean>(false), ReadOnly {
+class IsAssemblyInitializedEntryProcessor : AbstractReadOnlyRhizomeEntryProcessor<UUID, OrganizationAssembly, Boolean>() {
     override fun process(entry: MutableMap.MutableEntry<UUID, OrganizationAssembly?>): Boolean {
         val orgAssembly = entry.value ?: return false
         return orgAssembly.initialized

--- a/src/main/kotlin/com/openlattice/edm/processors/GetEntityTypeFromEntitySetEntryProcessor.kt
+++ b/src/main/kotlin/com/openlattice/edm/processors/GetEntityTypeFromEntitySetEntryProcessor.kt
@@ -3,9 +3,10 @@ package com.openlattice.edm.processors
 import com.hazelcast.core.ReadOnly
 import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor
 import com.openlattice.edm.EntitySet
+import com.openlattice.rhizome.hazelcast.entryprocessors.AbstractReadOnlyRhizomeEntryProcessor
 import java.util.*
 
-class GetEntityTypeFromEntitySetEntryProcessor : AbstractRhizomeEntryProcessor<UUID, EntitySet, Optional<UUID>>(), ReadOnly {
+class GetEntityTypeFromEntitySetEntryProcessor : AbstractReadOnlyRhizomeEntryProcessor<UUID, EntitySet, Optional<UUID>>() {
     override fun process(entry: MutableMap.MutableEntry<UUID, EntitySet?>): Optional<UUID> {
         val es = entry.value ?: return Optional.empty()
         return Optional.of( es.entityTypeId )

--- a/src/main/kotlin/com/openlattice/edm/processors/GetEntityTypeFromEntitySetEntryProcessor.kt
+++ b/src/main/kotlin/com/openlattice/edm/processors/GetEntityTypeFromEntitySetEntryProcessor.kt
@@ -1,14 +1,12 @@
 package com.openlattice.edm.processors
 
-import com.hazelcast.core.ReadOnly
-import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor
 import com.openlattice.edm.EntitySet
 import com.openlattice.rhizome.hazelcast.entryprocessors.AbstractReadOnlyRhizomeEntryProcessor
 import java.util.*
 
-class GetEntityTypeFromEntitySetEntryProcessor : AbstractReadOnlyRhizomeEntryProcessor<UUID, EntitySet, Optional<UUID>>() {
-    override fun process(entry: MutableMap.MutableEntry<UUID, EntitySet?>): Optional<UUID> {
-        val es = entry.value ?: return Optional.empty()
-        return Optional.of( es.entityTypeId )
+class GetEntityTypeFromEntitySetEntryProcessor : AbstractReadOnlyRhizomeEntryProcessor<UUID, EntitySet, UUID?>() {
+    override fun process(entry: MutableMap.MutableEntry<UUID, EntitySet?>): UUID? {
+        val es = entry.value ?: return null
+        return es.entityTypeId
     }
 }

--- a/src/main/kotlin/com/openlattice/edm/processors/GetPropertiesFromEntityTypeEntryProcessor.kt
+++ b/src/main/kotlin/com/openlattice/edm/processors/GetPropertiesFromEntityTypeEntryProcessor.kt
@@ -3,9 +3,10 @@ package com.openlattice.edm.processors
 import com.hazelcast.core.ReadOnly
 import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor
 import com.openlattice.edm.type.EntityType
+import com.openlattice.rhizome.hazelcast.entryprocessors.AbstractReadOnlyRhizomeEntryProcessor
 import java.util.*
 
-class GetPropertiesFromEntityTypeEntryProcessor: AbstractRhizomeEntryProcessor<UUID, EntityType, Optional<Set<UUID>>>(), ReadOnly {
+class GetPropertiesFromEntityTypeEntryProcessor: AbstractReadOnlyRhizomeEntryProcessor<UUID, EntityType, Optional<Set<UUID>>>() {
     override fun process(entry: MutableMap.MutableEntry<UUID, EntityType?>): Optional<Set<UUID>>? {
         val et = entry.value ?: return Optional.empty()
         return Optional.of( et.properties )

--- a/src/main/kotlin/com/openlattice/edm/processors/GetPropertiesFromEntityTypeEntryProcessor.kt
+++ b/src/main/kotlin/com/openlattice/edm/processors/GetPropertiesFromEntityTypeEntryProcessor.kt
@@ -1,14 +1,12 @@
 package com.openlattice.edm.processors
 
-import com.hazelcast.core.ReadOnly
-import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor
 import com.openlattice.edm.type.EntityType
 import com.openlattice.rhizome.hazelcast.entryprocessors.AbstractReadOnlyRhizomeEntryProcessor
 import java.util.*
 
-class GetPropertiesFromEntityTypeEntryProcessor: AbstractReadOnlyRhizomeEntryProcessor<UUID, EntityType, Optional<Set<UUID>>>() {
-    override fun process(entry: MutableMap.MutableEntry<UUID, EntityType?>): Optional<Set<UUID>>? {
-        val et = entry.value ?: return Optional.empty()
-        return Optional.of( et.properties )
+class GetPropertiesFromEntityTypeEntryProcessor: AbstractReadOnlyRhizomeEntryProcessor<UUID, EntityType, Set<UUID>>() {
+    override fun process(entry: MutableMap.MutableEntry<UUID, EntityType?>): Set<UUID>? {
+        val et = entry.value ?: return null
+        return et.properties
     }
 }


### PR DESCRIPTION
This PR:
- Uses new ReadOnly type so that the implementer doesn't have to pass a boolean to an implemented constructor