### PR TITLE
Debugging/oh lawg

### DIFF
--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -309,6 +309,7 @@ internal val upsertEntitiesSql = "UPDATE ${IDS.name} " +
 internal val getLinkingIdsOfEkidsSql = "SELECT ${ID.name}, ${LINKING_ID.name} " +
         "FROM ${IDS.name} " +
         "WHERE ${PARTITION.name} = ? " +
+        "AND ${PARTITIONS_VERSION.name} = ? " +
         "AND ${ID.name} = ANY(?) " +
         "AND ${LINKING_ID.name} IS NOT NULL"
 

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -300,6 +300,16 @@ internal val upsertEntitiesSql = "UPDATE ${IDS.name} " +
         "WHERE ${ENTITY_SET_ID.name} = ? AND ${ID_VALUE.name} = ANY(?) AND ${PARTITION.name} = ?"
 // @formatter:on
 
+
+/**
+ * Preparable sql to get linking ids of entity key ids
+ * 1. entity key ids
+ */
+internal val getLinkingIdsOfEkidsSql = "SELECT ${ID.name}, ${LINKING_ID.name} " +
+        "FROM ${IDS.name} " +
+        "WHERE ${ID.name} = ANY(?) " +
+        "AND ${LINKING_ID.name} IS NOT NULL"
+
 /**
  * Preparable sql to lock entities with the following bind order:
  * 1. entity key ids

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -303,12 +303,13 @@ internal val upsertEntitiesSql = "UPDATE ${IDS.name} " +
 
 /**
  * Preparable sql to get linking ids of entity key ids
- * 1. entity key ids
+ * 1. partition id
+ * 2. entity key ids
  */
 internal val getLinkingIdsOfEkidsSql = "SELECT ${ID.name}, ${LINKING_ID.name} " +
         "FROM ${IDS.name} " +
-        "WHERE ${ID.name} = ANY(?) " +
-        "AND ${PARTITION.name} = ? " +
+        "WHERE ${PARTITION.name} = ? " +
+        "AND ${ID.name} = ANY(?) " +
         "AND ${LINKING_ID.name} IS NOT NULL"
 
 /**

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -308,6 +308,7 @@ internal val upsertEntitiesSql = "UPDATE ${IDS.name} " +
 internal val getLinkingIdsOfEkidsSql = "SELECT ${ID.name}, ${LINKING_ID.name} " +
         "FROM ${IDS.name} " +
         "WHERE ${ID.name} = ANY(?) " +
+        "AND ${PARTITION.name} = ? " +
         "AND ${LINKING_ID.name} IS NOT NULL"
 
 /**

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -496,13 +496,13 @@ class PostgresEntityDataQueryService(
         val tombstoneFn: (Connection, Long, Map<UUID, UUID>, Map<UUID, Map<UUID, Set<Any>>>) ->
         Unit = { conn: Connection,
                  version: Long,
-                 ekidsToLinkingIds: Map<UUID, UUID>,
+                 entityKeyIdsToLinkingIds: Map<UUID, UUID>,
                  entityBatch: Map<UUID, Map<UUID, Set<Any>>> ->
             tombstone(
                     conn,
                     entitySetId,
                     entityBatch.keys,
-                    ekidsToLinkingIds,
+                    entityKeyIdsToLinkingIds,
                     propertyTypes,
                     version,
                     partitionsInfo
@@ -530,7 +530,7 @@ class PostgresEntityDataQueryService(
         val tombstoneFn =
                 { conn: Connection,
                   version: Long,
-                  ekidsToLinkingIds: Map<UUID, UUID>,
+                  entityKeyIdsToLinkingIds: Map<UUID, UUID>,
                   entityBatch: Map<UUID, Map<UUID, Set<Any>>> ->
                     entityBatch.forEach { (entityKeyId, entity) ->
                         //Implied access enforcement as it will raise exception if lacking permission
@@ -538,7 +538,7 @@ class PostgresEntityDataQueryService(
                                 conn,
                                 entitySetId,
                                 setOf(entityKeyId),
-                                ekidsToLinkingIds,
+                                entityKeyIdsToLinkingIds,
                                 entity.keys.map { authorizedPropertyTypes.getValue(it) }.toSet(),
                                 version,
                                 partitionsInfo
@@ -567,14 +567,14 @@ class PostgresEntityDataQueryService(
         val tombstoneFn: (Connection, Long, Map<UUID, UUID>, Map<UUID, Map<UUID, Set<Any>>>) -> Unit =
                 { conn: Connection,
                   version: Long,
-                  ekidsToLinkingIds: Map<UUID, UUID>,
+                  entityKeyIdsToLinkingIds: Map<UUID, UUID>,
                   entityBatch: Map<UUID, Map<UUID, Set<Any>>> ->
                     val ids = entityBatch.keys
                     tombstone(
                             conn,
                             entitySetId,
                             replacementProperties.filter { ids.contains(it.key) },
-                            ekidsToLinkingIds,
+                            entityKeyIdsToLinkingIds,
                             version,
                             partitionsInfo
                     )

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -1175,8 +1175,8 @@ class PostgresEntityDataQueryService(
                     val connection = hds.connection
                     val stmt = connection.prepareStatement(getLinkingIdsOfEkidsSql)
 
-                    stmt.setArray(1, PostgresArrays.createUuidArray(connection, entityKeyIds))
-                    stmt.setInt(2, partition)
+                    stmt.setInt(1, partition)
+                    stmt.setArray(2, PostgresArrays.createUuidArray(connection, entityKeyIds))
                     val rs = stmt.executeQuery()
                     StatementHolder(connection, stmt, rs)
                 },

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -1176,7 +1176,7 @@ class PostgresEntityDataQueryService(
                     val stmt = connection.prepareStatement(getLinkingIdsOfEkidsSql)
 
                     stmt.setArray(1, PostgresArrays.createUuidArray(connection, entityKeyIds))
-//                    stmt.setArray(2, )
+                    stmt.setInt(2, partition)
                     val rs = stmt.executeQuery()
                     StatementHolder(connection, stmt, rs)
                 },

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -252,6 +252,7 @@ class PostgresEntityDataQueryService(
         val version = System.currentTimeMillis()
         val entityKeyIdsToLinkingIds = getLinkingIdsOfEntityKeyIds(entities.keys)
 
+        // NO-OP
         val tombstoneFn = { _: Connection, _: Long, _: Map<UUID, Map<UUID, Set<Any>>> -> }
 
         return upsertEntities(
@@ -430,10 +431,13 @@ class PostgresEntityDataQueryService(
 
                     val maybeLinkingId = entityKeyIdsToLinkingIds[entityKeyId]
                     if (maybeLinkingId != null) {
+                        val linkPart = getPartition(maybeLinkingId, allPartitions)
                         // update for linked rows
                         upsertPropertyValue.second.setObject(1, entitySetId)
                         upsertPropertyValue.second.setObject(2, maybeLinkingId)
-                        upsertPropertyValue.second.setInt(3, getPartition(maybeLinkingId, allPartitions))
+                        upsertPropertyValue.second.setInt(3, linkPart )
+                        logger.info("LinkingId exists $maybeLinkingId on partition $linkPart for ekid $entityKeyId " +
+                                "which resides on partition $partition")
                         upsertPropertyValue.second.setObject(4, propertyTypeId)
                         upsertPropertyValue.second.setObject(5, propertyHash)
                         upsertPropertyValue.second.setObject(6, version)

--- a/src/main/kotlin/com/openlattice/data/storage/partitions/PartitionsInfo.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/partitions/PartitionsInfo.kt
@@ -5,6 +5,6 @@ package com.openlattice.data.storage.partitions
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 data class PartitionsInfo(
-        val partitions: Set<Int>,
+        val partitions: LinkedHashSet<Int>,
         val partitionsVersion: Int
 )


### PR DESCRIPTION
This PR:
- Updates a frequently used call (getLinkingIdsOfEntityKeyIds) to be used in a more centralized manner
- Refactors use pattern to prevent re-calling when the information is already in memory
- Makes invocations use partition instead of only using ekid