### PR TITLE
LATTICE-2335 Add support for disabling local audit in auditing.yaml

### DIFF
--- a/src/main/kotlin/com/openlattice/auditing/AuditingConfiguration.kt
+++ b/src/main/kotlin/com/openlattice/auditing/AuditingConfiguration.kt
@@ -35,5 +35,6 @@ data class AuditingConfiguration(
         @JsonProperty("edge-entity-type") val edgeEntityTypeFqn: String,
         @JsonProperty("fqns") val fqns: Map<AuditProperty, String>,
         @JsonProperty("aws") val awsS3ClientConfiguration: Optional<AwsS3ClientConfiguration>,
-        @JsonProperty("partitions") val partitions: Int = 257
+        @JsonProperty("partitions") val partitions: Int = 257,
+        @JsonProperty("enabled") val enabled: Boolean = true
 )

--- a/src/main/kotlin/com/openlattice/auditing/AuditingTypes.kt
+++ b/src/main/kotlin/com/openlattice/auditing/AuditingTypes.kt
@@ -81,6 +81,10 @@ class AuditingTypes(
         }
     }
 
+    fun enabled(): Boolean {
+        return auditingConfiguration.enabled
+    }
+
     fun isAuditingInitialized(): Boolean {
         if (!initialized) {
             intialize()

--- a/src/main/kotlin/com/openlattice/auditing/LocalAuditingService.kt
+++ b/src/main/kotlin/com/openlattice/auditing/LocalAuditingService.kt
@@ -22,6 +22,9 @@ class LocalAuditingService(
 
         val auditingConfiguration = ares.auditingTypes
 
+        if (!auditingConfiguration.enabled()) {
+            return 0
+        }
         if (!auditingConfiguration.isAuditingInitialized()) {
             return 0
         }

--- a/src/main/kotlin/com/openlattice/auditing/S3AuditingService.kt
+++ b/src/main/kotlin/com/openlattice/auditing/S3AuditingService.kt
@@ -37,6 +37,9 @@ class S3AuditingService(
         if (auditingConfiguration.awsS3ClientConfiguration.isEmpty) {
             throw IllegalStateException("Auditing configuration from auditing.yaml must include S3 configuration details.")
         }
+        if (!auditingConfiguration.enabled) {
+            throw IllegalStateException("Auditing configuration for s3 should not be disabled")
+        }
     }
 
     private val partitions = auditingConfiguration.partitions

--- a/src/main/resources/auditing.yaml
+++ b/src/main/resources/auditing.yaml
@@ -11,3 +11,4 @@ fqns:
   PRINCIPAL: "ol.userid"
   TIMESTAMP: "general.datetime"
   OPERATION_ID: "ol.auditeventid"
+enabled: false


### PR DESCRIPTION
Complain, loudly, if you try to do that with S3 since it shouldn't be disabled in prod.