### PR TITLE
add scripts to setup new citus, kill citus and docker-compose (from c…

### DIFF
--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2.1'
+
+services:
+  master:
+    container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
+    image: 'citusdata/citus:9.1.0'
+    ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
+    labels: ['com.citusdata.role=Master']
+  worker:
+    image: 'citusdata/citus:9.1.0'
+    labels: ['com.citusdata.role=Worker']
+    depends_on: { manager: { condition: service_healthy } }
+  manager:
+    container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
+    image: 'citusdata/membership-manager:0.2.0'
+    volumes: ['/var/run/docker.sock:/var/run/docker.sock']
+    depends_on: { master: { condition: service_healthy } }

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -14,23 +14,16 @@ then
   exit 1
 fi
 
-function runPsqlOnNode {
-  docker exec "$1" psql -U postgres -c "$2"
-}
-
-function runPsqlFileOnNodeWithOLDB {
-  docker exec "$1" psql -U postgres -d openlattice -f "$2"
-}
-
-function runPsqlFileOnNode {
-  docker exec "$1" psql -U postgres -f "$2"
+function runPsql {
+  container=$1
+  docker exec "$container" psql -U postgres "$@"
 }
 
 MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/docker-compose.yml up --scale worker=2 -d
 
 sleep 5
 
-NODES=$(runPsqlOnNode citus_master "SELECT * FROM master_get_active_worker_nodes();"  | grep worker | cut -d ' ' -f 2)
+NODES=$(docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();" | grep worker | cut -d ' ' -f 2)
 
 echo "current nodes: "
 for i in $NODES
@@ -54,20 +47,20 @@ docker cp "$dir"/alter_user.sql citus_master:/opt/
 docker cp "$dir"/alter_user.sql citus_worker_1:/opt/
 docker cp "$dir"/alter_user.sql citus_worker_2:/opt/
 
-runPsqlFileOnNode citus_master /opt/init_ol_db.sql
-runPsqlFileOnNode citus_worker_1 /opt/init_ol_db.sql
-runPsqlFileOnNode citus_worker_2 /opt/init_ol_db.sql
+runPsql citus_master -f /opt/init_ol_db.sql
+runPsql citus_worker_1 -f /opt/init_ol_db.sql
+runPsql citus_worker_2 -f /opt/init_ol_db.sql
 
-runPsqlFileOnNodeWithOLDB citus_master /opt/init_citus.sql
-runPsqlFileOnNodeWithOLDB citus_worker_1 /opt/init_citus.sql
-runPsqlFileOnNodeWithOLDB citus_worker_2 /opt/init_citus.sql
+runPsql citus_master -f /opt/init_citus.sql -d openlattice
+runPsql citus_worker_1 -f /opt/init_citus.sql -d openlattice
+runPsql citus_worker_2 -f /opt/init_citus.sql -d openlattice
 
-runPsqlFileOnNode citus_master /opt/create_user.sql
-runPsqlFileOnNode citus_worker_1 /opt/create_user.sql
-runPsqlFileOnNode citus_worker_2 /opt/create_user.sql
+runPsql citus_master -f /opt/create_user.sql
+runPsql citus_worker_1 -f /opt/create_user.sql
+runPsql citus_worker_2 -f /opt/create_user.sql
 
-runPsqlFileOnNode citus_master /opt/alter_user.sql
-runPsqlFileOnNode citus_worker_1 /opt/alter_user.sql
-runPsqlFileOnNode citus_worker_2 /opt/alter_user.sql
+runPsql citus_master -f /opt/alter_user.sql
+runPsql citus_worker_1 -f /opt/alter_user.sql
+runPsql citus_worker_2 -f /opt/alter_user.sql
 
 docker ps

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -30,11 +30,11 @@ sleep 5
 # sudo docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();"
 NODES=`runPsqlOnNode citus_master "SELECT * FROM master_get_active_worker_nodes();"  | grep worker | cut -d ' ' -f 2`
 
-# echo "Nodes: $NODES\n\n"
-# for i in $NODES
-# do
-  # sudo docker cp init_ol_db.sql $i:/opt/
-# done
+for i in $NODES
+do
+  echo "current nodes: "
+  echo "$i"
+done
 
 sudo docker cp init_ol_db.sql citus_master:/opt/
 sudo docker cp init_ol_db.sql citus_worker_1:/opt/
@@ -51,8 +51,6 @@ sudo docker cp create_user.sql citus_worker_2:/opt/
 sudo docker cp alter_user.sql citus_master:/opt/
 sudo docker cp alter_user.sql citus_worker_1:/opt/
 sudo docker cp alter_user.sql citus_worker_2:/opt/
-
-sudo docker exec -it citus_master cat /opt/init_ol_db.sql
 
 runPsqlFileOnNode citus_master /opt/init_ol_db.sql
 runPsqlFileOnNode citus_worker_1 /opt/init_ol_db.sql

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [[ $1 == *help || $1 == -h ]]
 then
@@ -8,23 +8,22 @@ then
 fi
 
 function runPsqlOnNode {
-  sudo docker exec $1 psql -U postgres -c "$2"
+  docker exec $1 psql -U postgres -c "$2"
 }
 
 function runPsqlFileOnNodeWithOLDB {
-  sudo docker exec $1 psql -U postgres -d openlattice -f $2
+  docker exec $1 psql -U postgres -d openlattice -f $2
 }
 
 function runPsqlFileOnNode {
-  sudo docker exec $1 psql -U postgres -f $2
+  docker exec $1 psql -U postgres -f $2
 }
 
 MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose up --scale worker=2 -d
 
 sleep 5
 
-# sudo docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();"
-NODES=`runPsqlOnNode citus_master "SELECT * FROM master_get_active_worker_nodes();"  | grep worker | cut -d ' ' -f 2`
+NODES=$(runPsqlOnNode citus_master "SELECT * FROM master_get_active_worker_nodes();"  | grep worker | cut -d ' ' -f 2)
 
 echo "current nodes: "
 for i in $NODES
@@ -32,21 +31,21 @@ do
   echo "$i"
 done
 
-sudo docker cp init_ol_db.sql citus_master:/opt/
-sudo docker cp init_ol_db.sql citus_worker_1:/opt/
-sudo docker cp init_ol_db.sql citus_worker_2:/opt/
+docker cp init_ol_db.sql citus_master:/opt/
+docker cp init_ol_db.sql citus_worker_1:/opt/
+docker cp init_ol_db.sql citus_worker_2:/opt/
 
-sudo docker cp init_citus.sql citus_master:/opt/
-sudo docker cp init_citus.sql citus_worker_1:/opt/
-sudo docker cp init_citus.sql citus_worker_2:/opt/
+docker cp init_citus.sql citus_master:/opt/
+docker cp init_citus.sql citus_worker_1:/opt/
+docker cp init_citus.sql citus_worker_2:/opt/
 
-sudo docker cp create_user.sql citus_master:/opt/
-sudo docker cp create_user.sql citus_worker_1:/opt/
-sudo docker cp create_user.sql citus_worker_2:/opt/
+docker cp create_user.sql citus_master:/opt/
+docker cp create_user.sql citus_worker_1:/opt/
+docker cp create_user.sql citus_worker_2:/opt/
 
-sudo docker cp alter_user.sql citus_master:/opt/
-sudo docker cp alter_user.sql citus_worker_1:/opt/
-sudo docker cp alter_user.sql citus_worker_2:/opt/
+docker cp alter_user.sql citus_master:/opt/
+docker cp alter_user.sql citus_worker_1:/opt/
+docker cp alter_user.sql citus_worker_2:/opt/
 
 runPsqlFileOnNode citus_master /opt/init_ol_db.sql
 runPsqlFileOnNode citus_worker_1 /opt/init_ol_db.sql

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -7,7 +7,7 @@ then
   echo "usage: initCitus"
   echo "This script will start up a local citus stack."
   echo "It *will* continue to run in the background after this script terminates."
-  echo "Use the $dir/killCitus.sh script to terminate citus if needed."
+  echo "Use the $dir/killCitus.sh script to terminate citus when needed."
   echo "You will lose any data stored in citus when you terminate it."
   exit 1
 fi
@@ -21,44 +21,36 @@ MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/do
 
 sleep 5
 
-NODES=$(docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();" | grep worker | cut -d ' ' -f 2)
-
-echo "current nodes: "
-for i in $NODES
-do
-  echo "$i"
-done
+NODES=$(docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();" | grep citus | cut -d ' ' -f 2)
 
 docker cp "$dir"/init_ol_db.sql citus_master:/opt/
-docker cp "$dir"/init_ol_db.sql citus_worker_1:/opt/
-docker cp "$dir"/init_ol_db.sql citus_worker_2:/opt/
-
 docker cp "$dir"/init_citus.sql citus_master:/opt/
-docker cp "$dir"/init_citus.sql citus_worker_1:/opt/
-docker cp "$dir"/init_citus.sql citus_worker_2:/opt/
-
 docker cp "$dir"/create_user.sql citus_master:/opt/
-docker cp "$dir"/create_user.sql citus_worker_1:/opt/
-docker cp "$dir"/create_user.sql citus_worker_2:/opt/
-
 docker cp "$dir"/alter_user.sql citus_master:/opt/
-docker cp "$dir"/alter_user.sql citus_worker_1:/opt/
-docker cp "$dir"/alter_user.sql citus_worker_2:/opt/
+
+echo "uploading sql scripts to nodes: "
+for i in ${NODES}
+do
+  docker cp "$dir"/init_ol_db.sql "$i":/opt/
+  docker cp "$dir"/init_citus.sql "$i":/opt/
+  docker cp "$dir"/create_user.sql "$i":/opt/
+  docker cp "$dir"/alter_user.sql "$i":/opt/
+  echo "$i: done"
+done
 
 runPsql citus_master -f /opt/init_ol_db.sql
-runPsql citus_worker_1 -f /opt/init_ol_db.sql
-runPsql citus_worker_2 -f /opt/init_ol_db.sql
-
 runPsql citus_master -f /opt/init_citus.sql -d openlattice
-runPsql citus_worker_1 -f /opt/init_citus.sql -d openlattice
-runPsql citus_worker_2 -f /opt/init_citus.sql -d openlattice
-
 runPsql citus_master -f /opt/create_user.sql
-runPsql citus_worker_1 -f /opt/create_user.sql
-runPsql citus_worker_2 -f /opt/create_user.sql
-
 runPsql citus_master -f /opt/alter_user.sql
-runPsql citus_worker_1 -f /opt/alter_user.sql
-runPsql citus_worker_2 -f /opt/alter_user.sql
+
+echo "running sql setup on nodes: "
+for i in ${NODES}
+do
+  runPsql "$i" -f /opt/init_ol_db.sql
+  runPsql "$i" -f /opt/init_citus.sql -d openlattice
+  runPsql "$i" -f /opt/create_user.sql
+  runPsql "$i" -f /opt/alter_user.sql
+  echo "$i: done"
+done
 
 docker ps

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -2,8 +2,6 @@
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-echo "$dir"
-
 if [[ $1 == *help || $1 == -h ]]
 then
   echo "usage: initCitus"
@@ -16,7 +14,7 @@ fi
 
 function runPsql {
   container=$1
-  docker exec "$container" psql -U postgres "$@"
+  docker exec ${container} psql -U postgres "${@:2}"
 }
 
 MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/docker-compose.yml up --scale worker=2 -d

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-dir="$(cd "$(dirname "$BASH_SOURCE[0]" )" && pwd)"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 echo "$dir"
 
@@ -26,7 +26,7 @@ function runPsqlFileOnNode {
   docker exec "$1" psql -U postgres -f "$2"
 }
 
-MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f $dir/docker-compose.yml up --scale worker=2 -d
+MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/docker-compose.yml up --scale worker=2 -d
 
 sleep 5
 
@@ -38,21 +38,21 @@ do
   echo "$i"
 done
 
-docker cp $dir/init_ol_db.sql citus_master:/opt/
-docker cp $dir/init_ol_db.sql citus_worker_1:/opt/
-docker cp $dir/init_ol_db.sql citus_worker_2:/opt/
+docker cp "$dir"/init_ol_db.sql citus_master:/opt/
+docker cp "$dir"/init_ol_db.sql citus_worker_1:/opt/
+docker cp "$dir"/init_ol_db.sql citus_worker_2:/opt/
 
-docker cp $dir/init_citus.sql citus_master:/opt/
-docker cp $dir/init_citus.sql citus_worker_1:/opt/
-docker cp $dir/init_citus.sql citus_worker_2:/opt/
+docker cp "$dir"/init_citus.sql citus_master:/opt/
+docker cp "$dir"/init_citus.sql citus_worker_1:/opt/
+docker cp "$dir"/init_citus.sql citus_worker_2:/opt/
 
-docker cp $dir/create_user.sql citus_master:/opt/
-docker cp $dir/create_user.sql citus_worker_1:/opt/
-docker cp $dir/create_user.sql citus_worker_2:/opt/
+docker cp "$dir"/create_user.sql citus_master:/opt/
+docker cp "$dir"/create_user.sql citus_worker_1:/opt/
+docker cp "$dir"/create_user.sql citus_worker_2:/opt/
 
-docker cp $dir/alter_user.sql citus_master:/opt/
-docker cp $dir/alter_user.sql citus_worker_1:/opt/
-docker cp $dir/alter_user.sql citus_worker_2:/opt/
+docker cp "$dir"/alter_user.sql citus_master:/opt/
+docker cp "$dir"/alter_user.sql citus_worker_1:/opt/
+docker cp "$dir"/alter_user.sql citus_worker_2:/opt/
 
 runPsqlFileOnNode citus_master /opt/init_ol_db.sql
 runPsqlFileOnNode citus_worker_1 /opt/init_ol_db.sql

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -11,10 +11,6 @@ function runPsqlOnNode {
   sudo docker exec $1 psql -U postgres -c "$2"
 }
 
-function runPsqlOnNodeWithOLDB {
-  sudo docker exec $1 psql -U postgres -d openlattice -c "$2"
-}
-
 function runPsqlFileOnNodeWithOLDB {
   sudo docker exec $1 psql -U postgres -d openlattice -f $2
 }
@@ -30,9 +26,9 @@ sleep 5
 # sudo docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();"
 NODES=`runPsqlOnNode citus_master "SELECT * FROM master_get_active_worker_nodes();"  | grep worker | cut -d ' ' -f 2`
 
+echo "current nodes: "
 for i in $NODES
 do
-  echo "current nodes: "
   echo "$i"
 done
 

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+if [[ $1 == *help || $1 == -h ]]
+then
+  echo "usage: initCitus"
+  echo "\n It is expected that this script is run from conductor-client/src/main/resources"
+  exit 1
+fi
+
+function runPsqlOnNode {
+  sudo docker exec $1 psql -U postgres -c "$2"
+}
+
+function runPsqlOnNodeWithOLDB {
+  sudo docker exec $1 psql -U postgres -d openlattice -c "$2"
+}
+
+function runPsqlFileOnNodeWithOLDB {
+  sudo docker exec $1 psql -U postgres -d openlattice -f $2
+}
+
+function runPsqlFileOnNode {
+  sudo docker exec $1 psql -U postgres -f $2
+}
+
+MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose up --scale worker=2 -d
+
+sleep 5
+
+# sudo docker exec citus_master psql -U postgres -c "SELECT * FROM master_get_active_worker_nodes();"
+NODES=`runPsqlOnNode citus_master "SELECT * FROM master_get_active_worker_nodes();"  | grep worker | cut -d ' ' -f 2`
+
+# echo "Nodes: $NODES\n\n"
+# for i in $NODES
+# do
+  # sudo docker cp init_ol_db.sql $i:/opt/
+# done
+
+sudo docker cp init_ol_db.sql citus_master:/opt/
+sudo docker cp init_ol_db.sql citus_worker_1:/opt/
+sudo docker cp init_ol_db.sql citus_worker_2:/opt/
+
+sudo docker cp init_citus.sql citus_master:/opt/
+sudo docker cp init_citus.sql citus_worker_1:/opt/
+sudo docker cp init_citus.sql citus_worker_2:/opt/
+
+sudo docker cp create_user.sql citus_master:/opt/
+sudo docker cp create_user.sql citus_worker_1:/opt/
+sudo docker cp create_user.sql citus_worker_2:/opt/
+
+sudo docker cp alter_user.sql citus_master:/opt/
+sudo docker cp alter_user.sql citus_worker_1:/opt/
+sudo docker cp alter_user.sql citus_worker_2:/opt/
+
+sudo docker exec -it citus_master cat /opt/init_ol_db.sql
+
+runPsqlFileOnNode citus_master /opt/init_ol_db.sql
+runPsqlFileOnNode citus_worker_1 /opt/init_ol_db.sql
+runPsqlFileOnNode citus_worker_2 /opt/init_ol_db.sql
+
+runPsqlFileOnNodeWithOLDB citus_master /opt/init_citus.sql
+runPsqlFileOnNodeWithOLDB citus_worker_1 /opt/init_citus.sql
+runPsqlFileOnNodeWithOLDB citus_worker_2 /opt/init_citus.sql
+
+runPsqlFileOnNode citus_master /opt/create_user.sql
+runPsqlFileOnNode citus_worker_1 /opt/create_user.sql
+runPsqlFileOnNode citus_worker_2 /opt/create_user.sql
+
+runPsqlFileOnNode citus_master /opt/alter_user.sql
+runPsqlFileOnNode citus_worker_1 /opt/alter_user.sql
+runPsqlFileOnNode citus_worker_2 /opt/alter_user.sql
+
+docker ps

--- a/src/main/resources/init_citus.sql
+++ b/src/main/resources/init_citus.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION citus;
+CREATE EXTENSION pgcrypto;

--- a/src/main/resources/init_ol_db.sql
+++ b/src/main/resources/init_ol_db.sql
@@ -1,0 +1,3 @@
+CREATE USER oltest with encrypted password 'test' superuser;
+CREATE DATABASE openlattice;
+GRANT ALL ON DATABASE openlattice to oltest;

--- a/src/main/resources/killCitus.sh
+++ b/src/main/resources/killCitus.sh
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-docker-compose stop
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-yes | docker-compose rm
+MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/docker-compose.yml down
 
-docker-compose ps
+yes | docker-compose -f "$dir"/docker-compose.yml rm
+
+docker ps

--- a/src/main/resources/killCitus.sh
+++ b/src/main/resources/killCitus.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker-compose stop
+
+yes | docker-compose rm
+
+docker-compose ps


### PR DESCRIPTION
This PR:
- Adds citus' docker-compose.yml (may want to nix that, I could go either way)
- Adds an initCitus script that starts citus and runs the appropriate postgres commands
- Adds a killCitus command that will tear-down citus
- Encapsulates database setup commands into sql files to be used with said script