### PR TITLE
Slight improvements to citus scripts

### DIFF
--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -3,11 +3,11 @@ version: '2.1'
 services:
   master:
     container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
-    image: 'citusdata/citus:9.1.0'
+    image: 'citusdata/citus:${CITUS_VERSION:-9.1.0}'
     ports: ["${MASTER_EXTERNAL_PORT:-5432}:5432"]
     labels: ['com.citusdata.role=Master']
   worker:
-    image: 'citusdata/citus:9.1.0'
+    image: 'citusdata/citus:${CITUS_VERSION:-9.1.0}'
     labels: ['com.citusdata.role=Worker']
     depends_on: { manager: { condition: service_healthy } }
   manager:

--- a/src/main/resources/initCitus.sh
+++ b/src/main/resources/initCitus.sh
@@ -14,10 +14,10 @@ fi
 
 function runPsql {
   container=$1
-  docker exec ${container} psql -U postgres "${@:2}"
+  docker exec "${container}" psql -U postgres "${@:2}"
 }
 
-MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/docker-compose.yml up --scale worker=2 -d
+MASTER_EXTERNAL_PORT=5433 docker-compose -p citus -f "$dir"/docker-compose.yml up --scale worker=2 -d
 
 sleep 5
 

--- a/src/main/resources/killCitus.sh
+++ b/src/main/resources/killCitus.sh
@@ -2,7 +2,7 @@
 
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-MASTER_EXTERNAL_PORT=5433 COMPOSE_PROJECT_NAME=citus docker-compose -f "$dir"/docker-compose.yml down
+MASTER_EXTERNAL_PORT=5433 docker-compose -p citus -f "$dir"/docker-compose.yml down
 
 yes | docker-compose -f "$dir"/docker-compose.yml rm
 


### PR DESCRIPTION
- use docker-compose -p instead of external env variable
- allow overriding the version of citus
- make shellcheck happy