### PR TITLE
Remove unused from exDBMService

### DIFF
--- a/src/main/kotlin/com/openlattice/data/storage/partitions/PartitionManager.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/partitions/PartitionManager.kt
@@ -2,6 +2,7 @@ package com.openlattice.data.storage.partitions
 
 import com.google.common.base.Preconditions.checkArgument
 import com.hazelcast.core.HazelcastInstance
+import com.openlattice.datastore.util.Util
 import com.openlattice.edm.EntitySet
 import com.openlattice.edm.processors.GetPartitionsFromEntitySetEntryProcessor
 import com.openlattice.edm.requests.MetadataUpdate
@@ -113,7 +114,7 @@ class PartitionManager @JvmOverloads constructor(
      * @param partitionCount The number of partitions to attempt to assign to the entity set.
      */
     fun reallocatePartitions(entitySetId: UUID, partitionCount: Int) {
-        val entitySet = entitySets.getValue(entitySetId)
+        val entitySet = Util.getSafely(entitySets, entitySetId)
         isValidAllocation(partitionCount)
         val allocatedPartitions = computePartitions(entitySet, partitionCount)
         setEntitySetPartitions(entitySetId, allocatedPartitions)

--- a/src/main/kotlin/com/openlattice/datastore/services/EntitySetService.kt
+++ b/src/main/kotlin/com/openlattice/datastore/services/EntitySetService.kt
@@ -21,8 +21,8 @@
 package com.openlattice.datastore.services
 
 import com.codahale.metrics.annotation.Timed
-import com.google.common.base.Preconditions.checkState
 import com.google.common.base.Preconditions.checkArgument
+import com.google.common.base.Preconditions.checkState
 import com.google.common.collect.Sets
 import com.google.common.eventbus.EventBus
 import com.hazelcast.core.HazelcastInstance
@@ -99,7 +99,7 @@ open class EntitySetService(
 
 
     override fun createEntitySet(principal: Principal, entitySet: EntitySet) {
-        val entityType = entityTypes.getValue(entitySet.entityTypeId)
+        val entityType = Util.getSafely(entityTypes, entitySet.entityTypeId)
         ensureValidEntitySet(entitySet)
 
         if (entitySet.partitions.isEmpty()) {
@@ -277,10 +277,7 @@ open class EntitySetService(
     }
 
     override fun getEntityTypeIdsByEntitySetIds(entitySetIds: Set<UUID>): Map<UUID, UUID> {
-        return entitySets.getAll(entitySetIds).entries.associateBy(
-                { e -> e.key },
-                { e -> e.value.entityTypeId }
-        )
+        return entitySets.executeOnKeys(entitySetIds, GetEntityTypeFromEntitySetEntryProcessor()) as Map<UUID, UUID>
     }
 
     override fun getAssociationTypeByEntitySetId(entitySetId: UUID): AssociationType {
@@ -343,12 +340,12 @@ open class EntitySetService(
     override fun getAllEntitySetPropertyMetadataForIds(
             entitySetIds: Set<UUID>
     ): Map<UUID, Map<UUID, EntitySetPropertyMetadata>> {
-        val entitySetsById = entitySets.getAll(entitySetIds)
-        val entityTypesById = entityTypes.getAll(entitySetsById.values.map(EntitySet::getEntityTypeId).toSet())
+        val entitySetTypesById = entitySets.executeOnKeys(entitySetIds, GetEntityTypeFromEntitySetEntryProcessor()) as Map<UUID, UUID>
+        val entityTypesById = entityTypes.getAll(entitySetTypesById.values.toSet())
 
         val keys = entitySetIds
                 .flatMap { entitySetId ->
-                    entityTypesById.getValue(entitySetsById.getValue(entitySetId).entityTypeId).properties
+                    entityTypesById.getValue(entitySetTypesById.getValue(entitySetId)).properties
                             .map { propertyTypeId ->
                                 EntitySetPropertyKey(entitySetId, propertyTypeId)
                             }
@@ -364,7 +361,7 @@ open class EntitySetService(
 
         missingKeys.forEach { newKey ->
             val propertyType = missingPropertyTypesById.getValue(newKey.propertyTypeId)
-            val propertyTags = entityTypesById.getValue(entitySetsById.getValue(newKey.entitySetId).entityTypeId)
+            val propertyTags = entityTypesById.getValue(entitySetTypesById.getValue(newKey.entitySetId))
                     .propertyTags.get(newKey.propertyTypeId)
 
             val defaultMetadata = EntitySetPropertyMetadata(

--- a/src/main/kotlin/com/openlattice/datastore/services/EntitySetService.kt
+++ b/src/main/kotlin/com/openlattice/datastore/services/EntitySetService.kt
@@ -340,12 +340,12 @@ open class EntitySetService(
     override fun getAllEntitySetPropertyMetadataForIds(
             entitySetIds: Set<UUID>
     ): Map<UUID, Map<UUID, EntitySetPropertyMetadata>> {
-        val entitySetTypesById = entitySets.executeOnKeys(entitySetIds, GetEntityTypeFromEntitySetEntryProcessor()) as Map<UUID, UUID>
-        val entityTypesById = entityTypes.getAll(entitySetTypesById.values.toSet())
+        val entityTypesByEntitySetId = entitySets.executeOnKeys(entitySetIds, GetEntityTypeFromEntitySetEntryProcessor()) as Map<UUID, UUID>
+        val entityTypesById = entityTypes.getAll(entityTypesByEntitySetId.values.toSet())
 
         val keys = entitySetIds
                 .flatMap { entitySetId ->
-                    entityTypesById.getValue(entitySetTypesById.getValue(entitySetId)).properties
+                    entityTypesById.getValue(entityTypesByEntitySetId.getValue(entitySetId)).properties
                             .map { propertyTypeId ->
                                 EntitySetPropertyKey(entitySetId, propertyTypeId)
                             }
@@ -361,7 +361,7 @@ open class EntitySetService(
 
         missingKeys.forEach { newKey ->
             val propertyType = missingPropertyTypesById.getValue(newKey.propertyTypeId)
-            val propertyTags = entityTypesById.getValue(entitySetTypesById.getValue(newKey.entitySetId))
+            val propertyTags = entityTypesById.getValue(entityTypesByEntitySetId.getValue(newKey.entitySetId))
                     .propertyTags.get(newKey.propertyTypeId)
 
             val defaultMetadata = EntitySetPropertyMetadata(

--- a/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
+++ b/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
@@ -25,7 +25,6 @@ import com.openlattice.organizations.mapstores.ORGANIZATION_ID_INDEX
 import com.openlattice.organizations.mapstores.TABLE_ID_INDEX
 import com.openlattice.organizations.roles.SecurePrincipalsManager
 import com.openlattice.postgres.*
-
 import com.openlattice.postgres.DataTables.quote
 import com.openlattice.postgres.ResultSetAdapters.*
 import com.openlattice.postgres.streams.BasePostgresIterable
@@ -56,7 +55,6 @@ class ExternalDatabaseManagementService(
 
     private val organizationExternalDatabaseColumns = HazelcastMap.ORGANIZATION_EXTERNAL_DATABASE_COLUMN.getMap( hazelcastInstance )
     private val organizationExternalDatabaseTables = HazelcastMap.ORGANIZATION_EXTERNAL_DATABASE_TABLE.getMap( hazelcastInstance )
-    private val hbaAuthenticationRecordsMapstore = HazelcastMap.HBA_AUTHENTICATION_RECORDS.getMap( hazelcastInstance )
     private val securableObjectTypes = HazelcastMap.SECURABLE_OBJECT_TYPES.getMap( hazelcastInstance )
     private val organizations = HazelcastMap.ORGANIZATIONS.getMap( hazelcastInstance )
     private val aces = HazelcastMap.PERMISSIONS.getMap( hazelcastInstance )


### PR DESCRIPTION
This PR:
- removes some .getValue on IMap b/c it does extra operations
- Update EntitySetService to use more EntryProcessors instead of .getAll on EntitySets