### PR TITLE
LATTICE-61 configuration service should load from aws

### DIFF
--- a/src/main/kotlin/com/openlattice/assembler/pods/AssemblerConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/assembler/pods/AssemblerConfigurationPod.kt
@@ -21,16 +21,12 @@
 
 package com.openlattice.assembler.pods
 
-import com.amazonaws.services.s3.AmazonS3
-import com.kryptnostic.rhizome.configuration.ConfigurationConstants
-import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
-import com.openlattice.ResourceConfigurationLoader
+import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.assembler.AssemblerConfiguration
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
+import javax.inject.Inject
 
 private val logger = LoggerFactory.getLogger(AssemblerConfigurationPod::class.java)
 
@@ -41,33 +37,11 @@ private val logger = LoggerFactory.getLogger(AssemblerConfigurationPod::class.ja
  */
 @Configuration
 class AssemblerConfigurationPod {
-    @Autowired(required = false)
-    private lateinit var awsS3: AmazonS3
+    @Inject
+    private lateinit var configurationLoader: ConfigurationLoader
 
-    @Autowired(required = false)
-    private lateinit var awsLaunchConfig: AmazonLaunchConfiguration
-
-    @Bean(name = ["assemblerConfiguration"])
-    @Profile(ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE)
-    fun localAssemblerConfiguration(): AssemblerConfiguration {
-        val config = ResourceConfigurationLoader.loadConfiguration(AssemblerConfiguration::class.java)
-        logger.info("Using local aws datastore configuration: {}", config)
-        return config
-    }
-
-    @Bean(name = ["assemblerConfiguration"])
-    @Profile(
-            ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE,
-            ConfigurationConstants.Profiles.AWS_TESTING_PROFILE
-    )
-    fun awsAssemblerConfiguration() : AssemblerConfiguration {
-        val config = ResourceConfigurationLoader.loadConfigurationFromS3(
-                awsS3,
-                awsLaunchConfig.bucket,
-                awsLaunchConfig.folder,
-                AssemblerConfiguration::class.java
-        )
-        logger.info("Using aws datastore configuration: {}", config)
-        return config
+    @Bean
+    fun assemblerConfiguration(): AssemblerConfiguration {
+        return configurationLoader.logAndLoad( "assembler", AssemblerConfiguration::class.java)
     }
 }

--- a/src/main/kotlin/com/openlattice/auditing/pods/AuditingConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/auditing/pods/AuditingConfigurationPod.kt
@@ -21,15 +21,11 @@
 
 package com.openlattice.auditing.pods
 
-import com.amazonaws.services.s3.AmazonS3
-import com.hazelcast.core.HazelcastInstance
-import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
 import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.ResourceConfigurationLoader
 import com.openlattice.auditing.AuditingConfiguration
 import com.openlattice.data.serializers.FullQualifiedNameJacksonSerializer
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import javax.inject.Inject
@@ -48,16 +44,7 @@ class AuditingConfigurationPod {
     }
 
     @Inject
-    private val hazelcastInstance: HazelcastInstance? = null
-
-    @Inject
     private lateinit var configurationLoader: ConfigurationLoader
-
-    @Autowired(required = false)
-    private val awsS3: AmazonS3? = null
-
-    @Autowired(required = false)
-    private val awsLaunchConfig: AmazonLaunchConfiguration? = null
 
     @Bean
     fun auditingConfiguration(): AuditingConfiguration {

--- a/src/main/kotlin/com/openlattice/auditing/pods/AuditingConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/auditing/pods/AuditingConfigurationPod.kt
@@ -23,8 +23,8 @@ package com.openlattice.auditing.pods
 
 import com.amazonaws.services.s3.AmazonS3
 import com.hazelcast.core.HazelcastInstance
-import com.kryptnostic.rhizome.configuration.ConfigurationConstants
 import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
+import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.ResourceConfigurationLoader
 import com.openlattice.auditing.AuditingConfiguration
 import com.openlattice.data.serializers.FullQualifiedNameJacksonSerializer
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import javax.inject.Inject
 
 private val logger = LoggerFactory.getLogger(AuditingConfigurationPod::class.java)
@@ -51,33 +50,17 @@ class AuditingConfigurationPod {
     @Inject
     private val hazelcastInstance: HazelcastInstance? = null
 
+    @Inject
+    private lateinit var configurationLoader: ConfigurationLoader
+
     @Autowired(required = false)
     private val awsS3: AmazonS3? = null
 
     @Autowired(required = false)
     private val awsLaunchConfig: AmazonLaunchConfiguration? = null
 
-    @Bean(name = ["auditingConfiguration"])
-    @Profile(ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE)
-    fun getLocalAuditingConfiguration(): AuditingConfiguration {
-        val config = ResourceConfigurationLoader.loadConfiguration(AuditingConfiguration::class.java)
-        logger.info("Using local aws auditing configuration: {}", config)
-        return config
-    }
-
-    @Bean(name = ["auditingConfiguration"])
-    @Profile(
-            ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE,
-            ConfigurationConstants.Profiles.AWS_TESTING_PROFILE
-    )
-    fun getAwsAuditingConfiguration(): AuditingConfiguration {
-        val config = ResourceConfigurationLoader.loadConfigurationFromS3(
-                awsS3!!,
-                awsLaunchConfig!!.bucket,
-                awsLaunchConfig.folder,
-                AuditingConfiguration::class.java
-        )
-        logger.info("Using aws auditing configuration: {}", config)
-        return config
+    @Bean
+    fun auditingConfiguration(): AuditingConfiguration {
+        return configurationLoader.logAndLoad( "auditing", AuditingConfiguration::class.java )
     }
 }

--- a/src/main/kotlin/com/openlattice/organizations/pods/OrganizationExternalDatabaseConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/organizations/pods/OrganizationExternalDatabaseConfigurationPod.kt
@@ -1,48 +1,21 @@
 package com.openlattice.organizations.pods
 
-import com.amazonaws.services.s3.AmazonS3
-import com.kryptnostic.rhizome.configuration.ConfigurationConstants
-import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
-import com.openlattice.ResourceConfigurationLoader
+import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.organizations.OrganizationExternalDatabaseConfiguration
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
+import javax.inject.Inject
 
 private val logger = LoggerFactory.getLogger(OrganizationExternalDatabaseConfigurationPod::class.java)
 
 @Configuration
 class OrganizationExternalDatabaseConfigurationPod {
+    @Inject
+    private lateinit var configurationLoader: ConfigurationLoader
 
-    @Autowired(required = false)
-    private lateinit var awsS3: AmazonS3
-
-    @Autowired(required = false)
-    private lateinit var awsLaunchConfig: AmazonLaunchConfiguration
-
-    @Bean(name = ["organizationExternalDatabaseConfiguration"])
-    @Profile(ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE)
-    fun getLocalOrganizationExternalDatabaseConfiguration(): OrganizationExternalDatabaseConfiguration {
-        val config = ResourceConfigurationLoader.loadConfiguration(OrganizationExternalDatabaseConfiguration::class.java)
-        logger.info("Using local organization external database configuration: {}", config)
-        return config
+    @Bean
+    fun organizationExternalDatabaseConfiguration(): OrganizationExternalDatabaseConfiguration {
+        return configurationLoader.logAndLoad( "organization external database", OrganizationExternalDatabaseConfiguration::class.java )
     }
-
-    @Bean(name = ["organizationExternalDatabaseConfiguration"])
-    @Profile(ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE,
-            ConfigurationConstants.Profiles.AWS_TESTING_PROFILE
-    )
-    fun getAwsOrganizationExternalDatabaseConfiguration(): OrganizationExternalDatabaseConfiguration {
-        val config = ResourceConfigurationLoader.loadConfigurationFromS3(
-                awsS3!!,
-                awsLaunchConfig!!.bucket,
-                awsLaunchConfig.folder,
-                OrganizationExternalDatabaseConfiguration::class.java
-        )
-        logger.info("Using aws organization external database configuration: {}", config)
-        return config
-    }
-
 }

--- a/src/main/kotlin/com/openlattice/twilio/pods/TwilioConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/twilio/pods/TwilioConfigurationPod.kt
@@ -1,48 +1,22 @@
 package com.openlattice.twilio.pods
 
-import com.amazonaws.services.s3.AmazonS3
-import com.kryptnostic.rhizome.configuration.ConfigurationConstants
-import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
-import com.openlattice.ResourceConfigurationLoader
+import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.twilio.TwilioConfiguration
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
+import javax.inject.Inject
 
 
 private val logger = LoggerFactory.getLogger(TwilioConfigurationPod::class.java)
 
 @Configuration
 class TwilioConfigurationPod {
-    @Autowired(required = false)
-    private lateinit var awsS3: AmazonS3
-
-    @Autowired(required = false)
-    private lateinit var awsLaunchConfig: AmazonLaunchConfiguration
+    @Inject
+    private lateinit var configurationLoader: ConfigurationLoader
 
     @Bean(name = ["twilioConfiguration"])
-    @Profile(ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE)
-    fun localTwilioConfiguration(): TwilioConfiguration {
-        val config = ResourceConfigurationLoader.loadConfiguration(TwilioConfiguration::class.java)
-        logger.info("Using local aws datastore configuration: {}", config)
-        return config
-    }
-
-    @Bean(name = ["twilioConfiguration"])
-    @Profile(
-            ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE,
-            ConfigurationConstants.Profiles.AWS_TESTING_PROFILE
-    )
-    fun awsTwilioConfiguration() : TwilioConfiguration {
-        val config = ResourceConfigurationLoader.loadConfigurationFromS3(
-                awsS3,
-                awsLaunchConfig.bucket,
-                awsLaunchConfig.folder,
-                TwilioConfiguration::class.java
-        )
-        logger.info("Using aws datastore configuration: {}", config)
-        return config
+    fun configurationLoader(): TwilioConfiguration {
+        return configurationLoader.logAndLoad( "twilio", TwilioConfiguration::class.java )
     }
 }

--- a/src/main/kotlin/com/openlattice/twilio/pods/TwilioConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/twilio/pods/TwilioConfigurationPod.kt
@@ -15,8 +15,8 @@ class TwilioConfigurationPod {
     @Inject
     private lateinit var configurationLoader: ConfigurationLoader
 
-    @Bean(name = ["twilioConfiguration"])
-    fun configurationLoader(): TwilioConfiguration {
+    @Bean
+    fun twilioConfiguration(): TwilioConfiguration {
         return configurationLoader.logAndLoad( "twilio", TwilioConfiguration::class.java )
     }
 }


### PR DESCRIPTION
Put configuration loader behind an interface that abstracts away
different config sources.

Also adds a configuration profile for running in a container and
loading from a fixed volume path, rather than from classpath.