### PR TITLE
Feature/lattice 2416 tables as metadata columns as data

### DIFF
--- a/src/main/java/com/openlattice/authorization/HazelcastSecurableObjectResolveTypeService.java
+++ b/src/main/java/com/openlattice/authorization/HazelcastSecurableObjectResolveTypeService.java
@@ -62,15 +62,11 @@ public class HazelcastSecurableObjectResolveTypeService implements SecurableObje
     }
 
     @Override
-    public Set<AclKey> getOrganizationExternalDatabaseAclKeys( Set<AclKey> aclKeys ) {
+    public Set<AclKey> getOrganizationExternalDbColumnAclKeys( Set<AclKey> aclKeys ) {
         return securableObjectTypes.keySet(
                 Predicates.and( Predicates.in(SecurableObjectTypeMapstore.ACL_KEY_INDEX, aclKeys.stream().map( AclKey::getIndex ).toArray( String[]::new ) ),
-                        Predicates.or(
                                 Predicates.equal( SecurableObjectTypeMapstore.SECURABLE_OBJECT_TYPE_INDEX,
-                                        SecurableObjectType.OrganizationExternalDatabaseColumn ),
-                                Predicates.equal( SecurableObjectTypeMapstore.SECURABLE_OBJECT_TYPE_INDEX,
-                                        SecurableObjectType.OrganizationExternalDatabaseTable )
-                        )
+                                        SecurableObjectType.OrganizationExternalDatabaseColumn )
                 )
         );
     }

--- a/src/main/java/com/openlattice/authorization/SecurableObjectResolveTypeService.java
+++ b/src/main/java/com/openlattice/authorization/SecurableObjectResolveTypeService.java
@@ -37,5 +37,5 @@ public interface SecurableObjectResolveTypeService {
 
     Set<AclKey> getSecurableObjectsOfType( SecurableObjectType type );
 
-    Set<AclKey> getOrganizationExternalDatabaseAclKeys( Set<AclKey> aclKeys);
+    Set<AclKey> getOrganizationExternalDbColumnAclKeys( Set<AclKey> aclKeys);
 }

--- a/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
+++ b/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
@@ -498,21 +498,6 @@ class ExternalDatabaseManagementService(
         return true
     }
 
-    private fun getMaintainColumnPrivilegesSql(aclKey: AclKey, principal: Principal, tableName: String, dbUser: String): List<String> {
-        val maintenanceStmts = mutableListOf<String>()
-        organizationExternalDatabaseColumns.values(belongsToTable(aclKey.last())).forEach {
-            val columnAclKey = AclKey(listOf(aclKey[0], it.id))
-            val columnAceKey = AceKey(columnAclKey, principal)
-            val columnAceValue = aces[columnAceKey]
-            if (columnAceValue != null) {
-                val columnPrivileges = getPrivilegesFromPermissions(columnAceValue.permissions)
-                val grantSql = createPrivilegesUpdateSql(Action.ADD, columnPrivileges, tableName, Optional.of(it.name), dbUser)
-                maintenanceStmts.add(grantSql)
-            }
-        }
-        return maintenanceStmts
-    }
-
     private fun getPrivilegesFromPermissions(permissions: EnumSet<Permission>): List<String> {
         val privileges = mutableListOf<String>()
         if (permissions.contains(Permission.OWNER)) {

--- a/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
+++ b/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
@@ -351,29 +351,19 @@ class ExternalDatabaseManagementService(
     }
 
     /**
-     * Sets privileges for a user on an organization's table or column
+     * Sets privileges for a user on an organization's column
      */
-    fun executePrivilegesUpdate(action: Action, acls: List<Acl>) {
-        //split acls between table and column objects
-        val aclsByType = acls.partition { it.aclKey.size == 1 }
-
-        val tableAclsByOrg = aclsByType.first.groupBy {
-            organizationExternalDatabaseTables.getValue(it.aclKey[0]).organizationId
-        }
-        val columnAclsByOrg = aclsByType.second.groupBy {
+    fun executePrivilegesUpdate(action: Action, columnAcls: List<Acl>) {
+        val columnAclsByOrg = columnAcls.groupBy {
             organizationExternalDatabaseColumns.getValue(it.aclKey[1]).organizationId
         }
-        val orgIds = tableAclsByOrg.keys + columnAclsByOrg.keys
 
-        orgIds.forEach { orgId ->
-            val orgAcls = tableAclsByOrg[orgId]?.toMutableList() ?: mutableListOf()
-            columnAclsByOrg[orgId]?.let { orgAcls.addAll(it) }
+        columnAclsByOrg.forEach { (orgId, columnAcls) ->
             val dbName = PostgresDatabases.buildOrganizationDatabaseName(orgId)
             acm.connect(dbName).connection.use { conn ->
                 conn.autoCommit = false
                 val stmt = conn.createStatement()
-                orgAcls.forEach {
-                    val aclKey = AclKey(it.aclKey)
+                columnAcls.forEach {
                     val tableAndColumnNames = getTableAndColumnNames(AclKey(it.aclKey))
                     val tableName = tableAndColumnNames.first
                     val columnName = tableAndColumnNames.second
@@ -387,26 +377,10 @@ class ExternalDatabaseManagementService(
                         if (action == Action.SET) {
                             val revokeSql = createPrivilegesUpdateSql(Action.REMOVE, listOf("ALL"), tableName, columnName, dbUser)
                             stmt.addBatch(revokeSql)
-
-                            //maintain column-level privileges if object is a table
-                            if (columnName.isEmpty) {
-                                getMaintainColumnPrivilegesSql(aclKey, ace.principal, tableName, dbUser).forEach { maintenanceStmt ->
-                                    stmt.addBatch(maintenanceStmt)
-                                }
-                            }
                         }
                         val privileges = getPrivilegesFromPermissions(ace.permissions)
                         val grantSql = createPrivilegesUpdateSql(action, privileges, tableName, columnName, dbUser)
                         stmt.addBatch(grantSql)
-
-                        //if we've removed privileges on a table, maintain column-level privileges
-                        if (action == Action.REMOVE) {
-                            if (columnName.isEmpty) {
-                                getMaintainColumnPrivilegesSql(aclKey, ace.principal, tableName, dbUser).forEach { maintenanceStmt ->
-                                    stmt.addBatch(maintenanceStmt)
-                                }
-                            }
-                        }
                     }
                     stmt.executeBatch()
                     conn.commit()
@@ -490,33 +464,22 @@ class ExternalDatabaseManagementService(
         return columnNames.joinToString(", ") { "DROP COLUMN $it" }
     }
 
-    private fun createPrivilegesUpdateSql(action: Action, privileges: List<String>, tableName: String, columnName: Optional<String>, dbUser: String): String {
+    private fun createPrivilegesUpdateSql(action: Action, privileges: List<String>, tableName: String, columnName: String, dbUser: String): String {
         val privilegesAsString = privileges.joinToString(separator = ", ")
         checkState(action == Action.REMOVE || action == Action.ADD || action == Action.SET,
                 "Invalid action $action specified")
-        var columnField = ""
-        columnName.ifPresent { columnField = "($it)" }
         return if (action == Action.REMOVE) {
-            "REVOKE $privilegesAsString $columnField ON $tableName FROM $dbUser"
+            "REVOKE $privilegesAsString ($columnName) ON $tableName FROM $dbUser"
         } else {
-            "GRANT $privilegesAsString $columnField ON $tableName TO $dbUser"
+            "GRANT $privilegesAsString ($columnName) ON $tableName TO $dbUser"
         }
     }
 
-    private fun getTableAndColumnNames(aclKey: AclKey): Pair<String, Optional<String>> {
-        val securableObjectType = securableObjectTypes[aclKey]!!
-        val tableName: String
-        val columnName: Optional<String>
-        val securableObjectId = aclKey.last()
-        if (securableObjectType == SecurableObjectType.OrganizationExternalDatabaseColumn) {
-            val organizationAtlasColumn = organizationExternalDatabaseColumns.getValue(securableObjectId)
-            tableName = organizationExternalDatabaseTables.getValue(organizationAtlasColumn.tableId).name
-            columnName = Optional.of(organizationAtlasColumn.name)
-        } else {
-            val organizationAtlasTable = organizationExternalDatabaseTables.getValue(securableObjectId)
-            tableName = organizationAtlasTable.name
-            columnName = Optional.empty()
-        }
+    private fun getTableAndColumnNames(aclKey: AclKey): Pair<String, String> {
+        val securableObjectId = aclKey[1]
+        val organizationAtlasColumn = organizationExternalDatabaseColumns.getValue(securableObjectId)
+        val tableName = organizationExternalDatabaseTables.getValue(organizationAtlasColumn.tableId).name
+        val columnName = organizationAtlasColumn.name
         return Pair(tableName, columnName)
     }
 

--- a/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
+++ b/src/main/kotlin/com/openlattice/organizations/ExternalDatabaseManagementService.kt
@@ -94,7 +94,8 @@ class ExternalDatabaseManagementService(
         return column.id
     }
 
-    fun getColumnMetadata(dbName: String, tableName: String, tableId: UUID, orgId: UUID, columnName: Optional<String>): BasePostgresIterable<OrganizationExternalDatabaseColumn> {
+    fun getColumnMetadata(dbName: String, tableName: String, tableId: UUID, orgId: UUID, columnName: Optional<String>): BasePostgresIterable<
+            OrganizationExternalDatabaseColumn> {
         var columnCondition = ""
         columnName.ifPresent { columnCondition = "AND information_schema.columns.column_name = '$it'" }
 
@@ -354,8 +355,10 @@ class ExternalDatabaseManagementService(
      * Sets privileges for a user on an organization's column
      */
     fun executePrivilegesUpdate(action: Action, columnAcls: List<Acl>) {
+        val columnIds = columnAcls.map { it.aclKey[1] }.toSet()
+        val columnsById = organizationExternalDatabaseColumns.getAll(columnIds)
         val columnAclsByOrg = columnAcls.groupBy {
-            organizationExternalDatabaseColumns.getValue(it.aclKey[1]).organizationId
+            columnsById.getValue(it.aclKey[1]).organizationId
         }
 
         columnAclsByOrg.forEach { (orgId, columnAcls) ->


### PR DESCRIPTION
This PR addresses the need to be able to view atlas table metadata without being able to see table data. We will now only grant postgres privileges on columns and not on entire tables. This will enable us to
-Use the OrgExternalDbTable object for permissioning table metadata
-Use the OrgExternalDbColumn object for permissioning table data on a column by column basis. 

This will make the external db objects act more like entity sets. The table will approximate the entity set and the columns will approximate the property types. 

One issue is that postgres privileges on entire tables will have no real meaning in our system, as read permissions on OrgExternalDbTable objects will only mean you can see the metadata. Super open to suggestions about this.