### PR TITLE
LATTICE-2418 pass whole entity set to EntitySetDataDeletedEvent

### DIFF
--- a/src/main/java/com/openlattice/search/SearchService.java
+++ b/src/main/java/com/openlattice/search/SearchService.java
@@ -265,10 +265,10 @@ public class SearchService {
     }
 
     @Subscribe
-    public void entitySetDataCleared( EntitySetDataDeletedEvent event ) {
+    public void entitySetDataDeleted( EntitySetDataDeletedEvent event ) {
         final var deleteEntitySetDataContext = deleteEntitySetDataTimer.time();
-        UUID entityTypeId = entitySetService.getEntityTypeByEntitySetId( event.getEntitySetId() ).getId();
-        final var entitySetDataDeleted = elasticsearchApi.clearEntitySetData( event.getEntitySetId(), entityTypeId );
+        final var entitySetDataDeleted = elasticsearchApi
+                .clearEntitySetData( event.getEntitySet().getId(), event.getEntitySet().getEntityTypeId() );
         deleteEntitySetDataContext.stop();
 
         if ( entitySetDataDeleted ) {
@@ -278,7 +278,7 @@ public class SearchService {
             // - let background task take soft deletes (would be too much overhead for clear calls)
             if ( event.getDeleteType() == DeleteType.Hard ) {
                 final var markAsIndexedContext = markAsIndexedTimer.time();
-                indexingMetadataManager.markAsUnIndexed( event.getEntitySetId() );
+                indexingMetadataManager.markAsUnIndexed( event.getEntitySet() );
                 markAsIndexedContext.stop();
             }
         }

--- a/src/main/kotlin/com/openlattice/data/storage/IndexingMetadataManager.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/IndexingMetadataManager.kt
@@ -2,6 +2,7 @@ package com.openlattice.data.storage
 
 import com.openlattice.data.EntityDataKey
 import com.openlattice.data.storage.partitions.PartitionManager
+import com.openlattice.edm.EntitySet
 import com.openlattice.postgres.DataTables.LAST_INDEX
 import com.openlattice.postgres.DataTables.LAST_LINK
 import com.openlattice.postgres.PostgresArrays
@@ -152,15 +153,13 @@ class IndexingMetadataManager(private val hds: HikariDataSource, private val par
     /**
      * Sets the last_write of provided entity set to current datetime. Used when un-indexing entities after entity set
      * data deletion.
-     * @param entitySetId The id of the (normal) entity set id.
+     * @param entitySet The (normal) entity set.
      */
-    fun markAsUnIndexed(entitySetId: UUID): Int {
-        val partitions = partitionManager.getEntitySetPartitions(entitySetId)
-
+    fun markAsUnIndexed(entitySet: EntitySet): Int {
         return hds.connection.use { connection ->
             connection.prepareStatement(markEntitySetLastIndexSql).use { stmt ->
-                val partitionsArray = PostgresArrays.createIntArray(connection, partitions)
-                stmt.setObject(1, entitySetId)
+                val partitionsArray = PostgresArrays.createIntArray(connection, entitySet.partitions)
+                stmt.setObject(1, entitySet.id)
                 stmt.setArray(2, partitionsArray)
 
                 stmt.executeUpdate()

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDatastore.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDatastore.kt
@@ -130,7 +130,7 @@ class PostgresEntityDatastore(
     }
 
     private fun signalEntitySetDataDeleted(entitySetId: UUID, deleteType: DeleteType) {
-        eventBus.post(EntitySetDataDeletedEvent(entitySetId, deleteType))
+        eventBus.post(EntitySetDataDeletedEvent(entitySetManager.getEntitySet(entitySetId)!!, deleteType))
         markMaterializedEntitySetDirty(entitySetId) // mark entityset as unsync with data
 
         // mark all involved linking entitysets as unsync with data

--- a/src/main/kotlin/com/openlattice/edm/events/EntitySetDataDeletedEvent.kt
+++ b/src/main/kotlin/com/openlattice/edm/events/EntitySetDataDeletedEvent.kt
@@ -21,6 +21,6 @@
 package com.openlattice.edm.events
 
 import com.openlattice.data.DeleteType
-import java.util.*
+import com.openlattice.edm.EntitySet
 
-data class EntitySetDataDeletedEvent(val entitySetId: UUID, val deleteType: DeleteType)
+data class EntitySetDataDeletedEvent(val entitySet: EntitySet, val deleteType: DeleteType)


### PR DESCRIPTION
This pr addresses this problem: When we delete an entity set and with it delete all of its entities, an EntitySetDataDeletedEvent gets posted (when the entity set is still existing) but sometimes by the time a subscriber handles the event, the entity set is already deleted, so it won't find its entity type, partitions...etc and an error gets thrown.