### PR TITLE
add search config to datastore configuration

### DIFF
--- a/src/main/java/com/openlattice/datastore/configuration/DatastoreConfiguration.kt
+++ b/src/main/java/com/openlattice/datastore/configuration/DatastoreConfiguration.kt
@@ -5,12 +5,14 @@ import com.kryptnostic.rhizome.configuration.Configuration
 import com.kryptnostic.rhizome.configuration.ConfigurationKey
 import com.kryptnostic.rhizome.configuration.SimpleConfigurationKey
 import com.kryptnostic.rhizome.configuration.annotation.ReloadableConfiguration
+import com.openlattice.conductor.rpc.SearchConfiguration
 
 const val BUCKET_NAME = "bucketName"
 const val REGION_NAME = "regionName"
 const val TIME_TO_LIVE = "timeToLive"
 const val ACCESS_KEY_ID = "accessKeyId"
 const val SECRET_ACCESS_KEY = "secretAccessKey"
+const val SEARCH_CONFIGURATION = "searchConfiguration"
 
 @ReloadableConfiguration(uri = "datastore.yaml")
 data class DatastoreConfiguration(
@@ -19,7 +21,8 @@ data class DatastoreConfiguration(
         @JsonProperty(TIME_TO_LIVE) val timeToLive: Long,
         @JsonProperty(ACCESS_KEY_ID) val accessKeyId: String,
         @JsonProperty(SECRET_ACCESS_KEY) val secretAccessKey: String,
-        @JsonProperty("googleMapsApiKey") val googleMapsApiKey: String = ""
+        @JsonProperty("googleMapsApiKey") val googleMapsApiKey: String = "",
+        @JsonProperty(SEARCH_CONFIGURATION ) val searchConfiguration: SearchConfiguration
 ) : Configuration {
 
     companion object {


### PR DESCRIPTION
This PR:
- Adds search configuration for elasticsearch to existing dastastore configuration for datastore.yaml