### PR TITLE
Lock ids to be updated in order.

### DIFF
--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -328,8 +328,8 @@ fun buildUpsertEntitiesAndLinkedData(): String {
             ","
     ) { "${it.name} = EXCLUDED.${it.name}" }
 
-
-    return "WITH linking_map as ($upsertEntitiesSql) INSERT INTO ${DATA.name} ($metadataColumnsSql,$insertColumns) " +
+    val lockingSql = "SELECT 1 FROM ${IDS.name} WHERE ${ENTITY_SET_ID.name} = ? AND ${ID_VALUE.name} = ANY(?) AND ${PARTITION.name} = ? ORDER BY ${ID_VALUE.name} FOR UPDATE "
+    return "WITH entity_locks as ($lockingSql), linking_map as ($upsertEntitiesSql) INSERT INTO ${DATA.name} ($metadataColumnsSql,$insertColumns) " +
             "SELECT $metadataReadColumnsSql,$insertColumns FROM ${DATA.name} INNER JOIN " +
             "linking_map USING(${ENTITY_SET_ID.name},${ID.name},${PARTITION.name}) " +
             "WHERE ${LINKING_ID.name} IS NOT NULL AND version > ? " +

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -367,7 +367,7 @@ class PostgresEntityDataQueryService(
     ): Int {
         return hds.connection.use { connection ->
             //Update the versions of all entities.
-            val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entities.keys)
+            val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entities.keys.sorted())
             val versionsArrays = PostgresArrays.createLongArray(connection, version)
 
             /*
@@ -412,14 +412,18 @@ class PostgresEntityDataQueryService(
             //Make data visible by marking new version in ids table.
             val upsertEntities = connection.prepareStatement(buildUpsertEntitiesAndLinkedData())
             val updatedLinkedEntities = attempt(LinearBackoff(60000, 125), 32) {
-                upsertEntities.setObject(1, versionsArrays)
-                upsertEntities.setObject(2, version)
-                upsertEntities.setObject(3, version)
-                upsertEntities.setObject(4, entitySetId)
-                upsertEntities.setArray(5, entityKeyIdsArr)
-                upsertEntities.setInt(6, partition)
-                upsertEntities.setInt(7, partition)
-                upsertEntities.setLong(8, version)
+                upsertEntities.setObject(1, entitySetId)
+                upsertEntities.setArray(2, entityKeyIdsArr)
+                upsertEntities.setInt(3, partition)
+
+                upsertEntities.setObject(4, versionsArrays)
+                upsertEntities.setObject(5, version)
+                upsertEntities.setObject(6, version)
+                upsertEntities.setObject(7, entitySetId)
+                upsertEntities.setArray(8, entityKeyIdsArr)
+                upsertEntities.setInt(9, partition)
+                upsertEntities.setInt(10, partition)
+                upsertEntities.setLong(11, version)
                 upsertEntities.executeUpdate()
             }
             logger.debug("Updated $updatedLinkedEntities linked entities as part of insert.")

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -367,7 +367,7 @@ class PostgresEntityDataQueryService(
     ): Int {
         return hds.connection.use { connection ->
             //Update the versions of all entities.
-            val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entities.keys.sorted())
+            val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entities.keys)
             val versionsArrays = PostgresArrays.createLongArray(connection, version)
 
             /*


### PR DESCRIPTION
This will prevent deadlocks by causing updates to ids to be ordered by entity key id.