### PR TITLE
Bugfix/reduce entity key id locking

### DIFF
--- a/src/main/java/com/openlattice/hazelcast/HazelcastMap.kt
+++ b/src/main/java/com/openlattice/hazelcast/HazelcastMap.kt
@@ -111,8 +111,6 @@ class HazelcastMap<K, V> internal constructor(val name: String) : TypedMapIdenti
         @JvmField val EXPIRATION_LOCKS = HazelcastMap<UUID, Long>("EXPIRATION_LOCKS")
         @JvmField val HBA_AUTHENTICATION_RECORDS = HazelcastMap<String, PostgresAuthenticationRecord>("HBA_AUTHENTICATION_RECORDS")
         @JvmField val ID_GENERATION = HazelcastMap<Long, Range>("ID_GENERATION")
-        @JvmField val ID_REF_COUNTS = HazelcastMap<EntityKey, Long>("ID_REF_COUNTS")
-        @JvmField val ID_CACHE = HazelcastMap<EntityKey, UUID>("ID_CACHE")
         @JvmField val INDEXING_JOBS = HazelcastMap<UUID, DelegatedUUIDSet>("INDEXING_JOBS")
         @JvmField val INDEXING_LOCKS = HazelcastMap<UUID, Long>("INDEXING_LOCKS")
         @JvmField val INDEXING_PROGRESS = HazelcastMap<UUID, UUID>("INDEXING_PROGRESS")

--- a/src/main/java/com/openlattice/ids/IdsGeneratingEntryProcessor.java
+++ b/src/main/java/com/openlattice/ids/IdsGeneratingEntryProcessor.java
@@ -23,6 +23,7 @@ package com.openlattice.ids;
 import com.google.common.annotations.VisibleForTesting;
 import com.hazelcast.core.Offloadable;
 import com.kryptnostic.rhizome.hazelcast.processors.AbstractRhizomeEntryProcessor;
+import com.openlattice.rhizome.hazelcast.DelegatedUUIDList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
@@ -44,7 +45,7 @@ public class IdsGeneratingEntryProcessor extends AbstractRhizomeEntryProcessor<I
         final Range range = entry.getValue(); //Range should never be null in the EP.
         final UUID[] ids = getIds( range );
         entry.setValue( range );
-        return Arrays.asList( ids );
+        return DelegatedUUIDList.wrap( Arrays.asList( ids ) );
     }
 
     public int getCount() {

--- a/src/main/kotlin/com/openlattice/data/ids/PostgresEntityKeyIdService.kt
+++ b/src/main/kotlin/com/openlattice/data/ids/PostgresEntityKeyIdService.kt
@@ -23,6 +23,7 @@ package com.openlattice.data.ids
 
 import com.geekbeast.hazelcast.HazelcastClientProvider
 import com.google.common.base.Preconditions.checkState
+import com.google.common.collect.Queues
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.openlattice.IdConstants
 import com.openlattice.data.EntityKey
@@ -39,13 +40,13 @@ import com.openlattice.postgres.PostgresTable.*
 import com.openlattice.postgres.ResultSetAdapters
 import com.openlattice.postgres.streams.BasePostgresIterable
 import com.openlattice.postgres.streams.PreparedStatementHolderSupplier
-import com.openlattice.postgres.streams.StatementHolder
 import com.zaxxer.hikari.HikariDataSource
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind
 import org.slf4j.LoggerFactory
 import java.sql.Connection
+import java.sql.PreparedStatement
 import java.util.*
-import java.util.function.Supplier
+import java.util.concurrent.BlockingQueue
 import kotlin.collections.HashMap
 
 /**
@@ -57,29 +58,24 @@ private val entityKeyIdsSql = "SELECT * FROM ${SYNC_IDS.name} WHERE ${ENTITY_SET
 private val entityKeyIdSql = "SELECT * FROM ${SYNC_IDS.name} WHERE ${ENTITY_SET_ID.name} = ? AND ${ENTITY_ID.name} = ? "
 private val linkedEntityKeyIdsSql = "SELECT ${ID.name},${LINKING_ID.name} as $ENTITY_KEY_IDS_FIELD FROM ${IDS.name} WHERE ${ID.name} = ANY(?) AND ${LINKING_ID.name} IS NOT NULL"
 
-private val INSERT_SQL = "INSERT INTO ${IDS.name} (${ENTITY_SET_ID.name},${ID.name},${PARTITION.name}) VALUES(?,?,?)"
+private val INSERT_SQL = "INSERT INTO ${IDS.name} (${ENTITY_SET_ID.name},${ID.name},${PARTITION.name}) VALUES(?,?,?) ON CONFLICT DO NOTHING"
 private val INSERT_ID_TO_DATA_SQL = "INSERT INTO ${DATA.name} (" +
         "${ENTITY_SET_ID.name}," +
         "${ID.name}," +
         "${PARTITION.name}," +
         "${PROPERTY_TYPE_ID.name}," +
         "${VERSION.name}," +
-        "${HASH.name}) VALUES (?,?,?,?,?,?)"
-private val INSERT_SYNC_SQL = "INSERT INTO ${SYNC_IDS.name} (${ENTITY_SET_ID.name},${ENTITY_ID.name},${ID.name}) VALUES(?,?,?)"
+        "${HASH.name}) VALUES (?,?,?,?,?,?) " +
+        "ON CONFLICT DO NOTHING"
+private val INSERT_SYNC_SQL = "INSERT INTO ${SYNC_IDS.name} (${ENTITY_SET_ID.name},${ENTITY_ID.name},${ID.name}) VALUES(?,?,?) ON CONFLICT DO NOTHING"
 
 private val logger = LoggerFactory.getLogger(PostgresEntityKeyIdService::class.java)
 
 class PostgresEntityKeyIdService(
-        hazelcastClients: HazelcastClientProvider,
-        private val executor: ListeningExecutorService,
         private val hds: HikariDataSource,
         private val idGenerationService: HazelcastIdGenerationService,
         private val partitionManager: PartitionManager
 ) : EntityKeyIdService {
-    private val hazelcastInstance = hazelcastClients.getClient(HazelcastClient.IDS.name)
-    private val idRefCounts = HazelcastMap.ID_REF_COUNTS.getMap(hazelcastInstance)
-    private val idMap = HazelcastMap.ID_CACHE.getMap(hazelcastInstance)
-
     private fun genEntityKeyIds(entityIds: Set<EntityKey>): Map<EntityKey, UUID> {
         val ids = idGenerationService.getNextIds(entityIds.size)
         checkState(ids.size == entityIds.size, "Insufficient ids generated.")
@@ -87,59 +83,41 @@ class PostgresEntityKeyIdService(
     }
 
     private fun storeEntityKeyIdReservations(
-            entitySetId: UUID, entityKeyIds: Set<UUID>,
-            partitions: Set<Int> = partitionManager.getEntitySetPartitions(entitySetId)
+            entitySetId: UUID,
+            entityKeyIds: Set<UUID>,
+            partitions: Array<Int> = partitionManager.getEntitySetPartitions(entitySetId).toTypedArray()
     ) {
         hds.connection.use { connection ->
-            connection.autoCommit = false
-
             val insertIds = connection.prepareStatement(INSERT_SQL)
             val insertToData = connection.prepareStatement(INSERT_ID_TO_DATA_SQL)
 
             entityKeyIds.forEach { entityKeyId ->
-                val partition = getPartition(entityKeyId, partitions.toList())
-
-                insertIds.setObject(1, entitySetId)
-                insertIds.setObject(2, entityKeyId)
-                insertIds.setInt(3, partition)
-                insertIds.addBatch()
-
-                insertToData.setObject(1, entitySetId)
-                insertToData.setObject(2, entityKeyId)
-                insertToData.setInt(3, partition)
-                insertToData.setObject(4, IdConstants.ID_ID.id)
-                insertToData.setLong(5, System.currentTimeMillis())
-                insertToData.setObject(6, PostgresDataHasher.hashObject(entityKeyId, EdmPrimitiveTypeKind.Guid))
-                insertToData.addBatch()
+                storeEntityKeyIdAddBatch(entitySetId, entityKeyId, insertIds, insertToData, partitions)
             }
 
             val totalWritten = insertIds.executeBatch().sum()
             val totalDataRowsWritten = insertToData.executeBatch().sum()
-            if (totalWritten != entityKeyIds.size) {
-                logger.warn("Expected ${entityKeyIds.size} entity key id writes. Only $totalWritten writes registered.")
-            }
-            if (totalDataRowsWritten != entityKeyIds.size) {
-                logger.warn(
-                        "Expected ${entityKeyIds.size} entityKeyId data writes. Only $totalDataRowsWritten writes registered."
-                )
-            }
-            connection.commit()
-            connection.autoCommit = true
+            logger.debug("Inserted $totalWritten ids.")
+            logger.debug("Inserted $totalDataRowsWritten data ids.")
         }
     }
 
-    private fun storeEntityKeyIds(
-            entityKeyIds: Map<EntityKey, UUID>, conn: Connection = hds.connection
-    ): Map<EntityKey, UUID> {
-        val partitionsByEntitySet = partitionManager.getPartitionsByEntitySetId(
-                entityKeyIds.keys.map { it.entitySetId }.toSet()
-        ).mapValues { it.value.toList() }
-
-        conn.use { connection ->
-            connection.autoCommit = false
-
+    private fun storeEntityKeyIds(entityKeyIds: Map<EntityKey, UUID>): Map<EntityKey, UUID> {
+        val partitionsByEntitySet = partitionManager
+                .getPartitionsByEntitySetId(entityKeyIds.keys.map { it.entitySetId }.toSet())
+                .mapValues { it.value.toTypedArray() }
+        /**
+         * The new algorithm will result in more reads, but reduce the amount of hazelcast traffic
+         * for locking during id generation. This will only happen if a request to assign entity key ids
+         * to a large number of overlapping sets of entity keys not already in the system. Otherwise,
+         * this function won't be called as the assignment will be read further up.
+         *
+         * 1. Attempt to insert into sync ids (will silently fail if already inserted.
+         * 2. Load all actual entity key ids for sync ids
+         * 3. Issue batched inserts for actual entity key ids. May end up performin a lot of no-ops.
+         */
+        return hds.connection.use { connection ->
             val insertSyncIds = connection.prepareStatement(INSERT_SYNC_SQL)
-
             entityKeyIds.forEach {
                 insertSyncIds.setObject(1, it.key.entitySetId)
                 insertSyncIds.setString(2, it.key.entityId)
@@ -147,103 +125,93 @@ class PostgresEntityKeyIdService(
                 insertSyncIds.addBatch()
             }
 
+            val totalSyncIdRowsWritten = insertSyncIds.executeBatch()
+
+            val syncIds = entityKeyIds.keys
+                    .groupBy({ it.entitySetId }, { it.entityId })
+                    .mapValues { it.value.toSet() }
+
+            val actualEntityKeyIds = loadEntityKeyIds(syncIds)
+
             val insertIds = connection.prepareStatement(INSERT_SQL)
             val insertToData = connection.prepareStatement(INSERT_ID_TO_DATA_SQL)
 
-            entityKeyIds.forEach {
-                val partition = getPartition(it.value, partitionsByEntitySet.getValue(it.key.entitySetId))
-
-                insertIds.setObject(1, it.key.entitySetId)
-                insertIds.setObject(2, it.value)
-                insertIds.setInt(3, partition)
-                insertIds.addBatch()
-
-                insertToData.setObject(1, it.key.entitySetId)
-                insertToData.setObject(2, it.value)
-                insertToData.setInt(3, partition)
-                insertToData.setObject(4, IdConstants.ID_ID.id)
-                insertToData.setLong(5, System.currentTimeMillis())
-                insertToData.setObject(6, PostgresDataHasher.hashObject(it.value, EdmPrimitiveTypeKind.Guid))
-                insertToData.addBatch()
+            actualEntityKeyIds.forEach {
+                storeEntityKeyIdAddBatch(
+                        it.key.entitySetId,
+                        entityKeyId = it.value,
+                        insertIds = insertIds,
+                        insertToData = insertToData,
+                        partitions = partitionsByEntitySet.getValue(it.key.entitySetId)
+                )
             }
 
-            val totalSyncIdRowsWritten = insertSyncIds.executeBatch().sum()
             val totalWritten = insertIds.executeBatch().sum()
-            val dataRowsWritten = insertToData.executeBatch().sum()
+            val totalDataRowsWritten = insertToData.executeBatch().sum()
 
-            if (totalSyncIdRowsWritten != entityKeyIds.size) {
-                logger.warn(
-                        "Expected ${entityKeyIds.size} sync id writes. Only $totalSyncIdRowsWritten writes registered."
-                )
+            if (logger.isDebugEnabled) {
+                logger.debug("Inserted ${totalSyncIdRowsWritten.sum()} sync ids.")
+                logger.debug("Inserted $totalWritten ids.")
+                logger.debug("Inserted $totalDataRowsWritten data ids.")
             }
-            if (totalWritten != entityKeyIds.size) {
-                logger.warn("Expected ${entityKeyIds.size} entity key writes. Only $totalWritten writes registered.")
-            }
-            if (dataRowsWritten != entityKeyIds.size) {
-                logger.warn(
-                        "Expected ${entityKeyIds.size} entityKeyId data writes. Only $dataRowsWritten writes registered."
-                )
-            }
-            connection.commit()
-            connection.autoCommit = true
-        }
-        return entityKeyIds
-    }
 
-    private fun countUpEntityKeys(entityKeys: Set<EntityKey>) {
-        idRefCounts.executeOnKeys(entityKeys, IdRefCountIncrementer())
-
-    }
-
-    private fun countDownEntityKeys(entityKeys: Set<EntityKey>) {
-        idRefCounts.executeOnKeys(entityKeys, IdRefCountDecrementer())
-                .forEach { (entityKey, count) ->
-                    if (count == 0) {
-                        idMap.delete(entityKey)
-                    }
+            //Take the actual entity key ids of instead of the generated ones.
+            entityKeyIds.mapValues {
+                val actualEntityKeyId = actualEntityKeyIds[it.key]
+                return@mapValues if (actualEntityKeyId == null) {
+                    it.value
+                } else {
+                    idGenerationService.returnId(it.value)
+                    actualEntityKeyId
                 }
+            }
+        }
+    }
+
+    private fun storeEntityKeyIdAddBatch(
+            entitySetId: UUID,
+            entityKeyId: UUID,
+            insertIds: PreparedStatement,
+            insertToData: PreparedStatement,
+            partitions: Array<Int> = partitionManager.getEntitySetPartitions(entitySetId).toTypedArray()
+    ) {
+        val partition = getPartition(entityKeyId, partitions)
+
+        insertIds.setObject(1, entitySetId)
+        insertIds.setObject(2, entityKeyId)
+        insertIds.setInt(3, partition)
+        insertIds.addBatch()
+
+        insertToData.setObject(1, entitySetId)
+        insertToData.setObject(2, entityKeyId)
+        insertToData.setInt(3, partition)
+        insertToData.setObject(4, IdConstants.ID_ID.id)
+        insertToData.setLong(5, System.currentTimeMillis())
+        insertToData.setObject(6, PostgresDataHasher.hashObject(entityKeyId, EdmPrimitiveTypeKind.Guid))
+        insertToData.addBatch()
     }
 
     private fun assignEntityKeyIds(entityKeys: Set<EntityKey>): Map<EntityKey, UUID> {
-        val unassignedEntityKeyIds = mutableMapOf<EntityKey, UUID>()
-        //Create map of assignedEntityKeys and unassignedEntityKey is in single pass
-        val assignedEntityKeyIds = entityKeys.associateWith { key ->
-            val elem = idGenerationService.getNextId()
-            val id = idMap.putIfAbsent(key, elem)
-            if (id == null) {
-                unassignedEntityKeyIds[key] = elem
-                elem
-            } else {
-                idGenerationService.returnId(elem)
-                id
-            }
-        }
-
-        storeEntityKeyIds(unassignedEntityKeyIds)
-        return assignedEntityKeyIds
+        val assignedEntityKeyIds = entityKeys.associateWith { idGenerationService.getNextId() }
+        return storeEntityKeyIds(assignedEntityKeyIds)
     }
 
     override fun reserveEntityKeyIds(entityKeys: Set<EntityKey>): Set<UUID> {
-        val entityIdsByEntitySet = entityKeys.groupBy({ it.entitySetId },
-                                                      { it.entityId }).mapValues { it.value.toSet() }
+        val entityIdsByEntitySet = entityKeys
+                .groupBy({ it.entitySetId }, { it.entityId })
+                .mapValues { it.value.toSet() }
         val existing = loadEntityKeyIds(entityIdsByEntitySet)
         val missing = entityKeys - existing.keys
-
-        countUpEntityKeys(missing)
-
         val missingMap = assignEntityKeyIds(missing)
 
-        countDownEntityKeys(missing)
-
         return entityKeys.asSequence().map { existing[it] ?: missingMap.getValue(it) }.toSet()
-
     }
 
     override fun reserveLinkingIds(count: Int): List<UUID> {
         val ids = idGenerationService.getNextIds(count)
         storeEntityKeyIdReservations(
                 IdConstants.LINKING_ENTITY_SET_ID.id, ids,
-                partitionManager.getAllPartitions().toSet()
+                partitionManager.getAllPartitions().toTypedArray()
         )
         return ids.toList()
     }
@@ -283,7 +251,6 @@ class PostgresEntityKeyIdService(
 
     private fun loadEntityKeyIds(entityIds: Map<UUID, Set<String>>): MutableMap<EntityKey, UUID> {
         return hds.connection.use { connection ->
-
             val ids = HashMap<EntityKey, UUID>(entityIds.values.sumBy { it.size })
 
             val ps = connection.prepareStatement(entityKeyIdsSql)
@@ -296,17 +263,16 @@ class PostgresEntityKeyIdService(
                             ids[ResultSetAdapters.entityKey(rs)] = ResultSetAdapters.id(rs)
                         }
                     }
-
-            return ids
+            ids
         }
     }
 
     /**
      * @return A map of entity key ids to linking ids
      */
-    override fun getLinkingEntityKeyIds( entityKeyIds: Set<UUID> ) : Map<UUID, UUID> {
-        return BasePostgresIterable(PreparedStatementHolderSupplier(hds, linkedEntityKeyIdsSql ) {
-            it.setArray(1, PostgresArrays.createUuidArray(it.connection,entityKeyIds))
+    override fun getLinkingEntityKeyIds(entityKeyIds: Set<UUID>): Map<UUID, UUID> {
+        return BasePostgresIterable(PreparedStatementHolderSupplier(hds, linkedEntityKeyIdsSql) {
+            it.setArray(1, PostgresArrays.createUuidArray(it.connection, entityKeyIds))
         }) {
             it.getObject(ID.name, UUID::class.java) to it.getObject(LINKING_ID.name, UUID::class.java)
         }.toMap()
@@ -316,19 +282,14 @@ class PostgresEntityKeyIdService(
             entityKeys: Set<EntityKey>,
             entityKeyIds: MutableMap<EntityKey, UUID>
     ): MutableMap<EntityKey, UUID> {
-        val entityIdsByEntitySet = entityKeys.groupBy({ it.entitySetId },
-                                                      { it.entityId }).mapValues { it.value.toSet() }
+        val entityIdsByEntitySet = entityKeys
+                .groupBy({ it.entitySetId }, { it.entityId })
+                .mapValues { it.value.toSet() }
         entityKeyIds.putAll(loadEntityKeyIds(entityIdsByEntitySet))
 
         //Making this line O(n) is why we chose to just take a set instead of a sequence (thus allowing lazy views since copy is required anyway)
         val missing = entityKeys.minus(entityKeyIds.keys)
-
-        countUpEntityKeys(missing)
-
         val missingMap = assignEntityKeyIds(missing)
-
-        countDownEntityKeys(missing)
-
         entityKeyIds.putAll(missingMap)
 
         return entityKeyIds
@@ -357,7 +318,7 @@ class PostgresEntityKeyIdService(
             val rs = ps.executeQuery()
 
             while (rs.next()) {
-                entries.put(ResultSetAdapters.id(rs), ResultSetAdapters.entityKey(rs))
+                entries[ResultSetAdapters.id(rs)] = ResultSetAdapters.entityKey(rs)
             }
         }
 

--- a/src/main/kotlin/com/openlattice/data/storage/IndexingMetadataManager.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/IndexingMetadataManager.kt
@@ -2,6 +2,7 @@ package com.openlattice.data.storage
 
 import com.openlattice.data.EntityDataKey
 import com.openlattice.data.storage.partitions.PartitionManager
+import com.openlattice.data.storage.partitions.getPartition
 import com.openlattice.postgres.DataTables.LAST_INDEX
 import com.openlattice.postgres.DataTables.LAST_LINK
 import com.openlattice.postgres.PostgresArrays
@@ -33,7 +34,11 @@ class IndexingMetadataManager(private val hds: HikariDataSource, private val par
 
                     val partitions = entitySetPartitions.getValue(entitySetId).toList()
                     entities.entries
-                            .groupBy({ getPartition(it.key, partitions) }, { it.toPair() })
+                            .groupBy({
+                                         getPartition(
+                                                 it.key, partitions
+                                         )
+                                     }, { it.toPair() })
                             .mapValues { it.value.toMap() }
                             .forEach { (partition, entitiesWithLastWrite) ->
 
@@ -70,7 +75,11 @@ class IndexingMetadataManager(private val hds: HikariDataSource, private val par
 
                     val partitions = entitySetPartitions.getValue(entitySetId).toList()
                     entities.entries
-                            .groupBy({ getPartition(it.key, partitions) }, { it.toPair() })
+                            .groupBy({
+                                         getPartition(
+                                                 it.key, partitions
+                                         )
+                                     }, { it.toPair() })
                             .mapValues { it.value.toMap() }
                             .forEach { (partition, linkingIdsByOriginId) ->
 
@@ -133,7 +142,11 @@ class IndexingMetadataManager(private val hds: HikariDataSource, private val par
 
                     val partitions = entitySetPartitions.getValue(entitySetId).toList()
 
-                    entities.groupBy { getPartition(it, partitions) }
+                    entities.groupBy {
+                        getPartition(
+                                it, partitions
+                        )
+                    }
                             .forEach { (partition, entities) ->
 
                                 val idsArray = PostgresArrays.createUuidArray(connection, entities)
@@ -198,7 +211,11 @@ class IndexingMetadataManager(private val hds: HikariDataSource, private val par
                 normalEntityKeys.forEach { (entitySetId, normalIds) ->
                     val partitions = entitySetPartitions.getValue(entitySetId).toList()
 
-                    normalIds.groupBy { getPartition(it, partitions) }
+                    normalIds.groupBy {
+                        getPartition(
+                                it, partitions
+                        )
+                    }
                             .forEach { (partition, normalEntityKeyIds) ->
                                 val normalEntityKeyIdsArray = PostgresArrays.createUuidArray(connection, normalEntityKeyIds)
                                 stmt.setObject(1, entitySetId)

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -4,6 +4,7 @@ package com.openlattice.data.storage
 import com.openlattice.IdConstants
 import com.openlattice.analysis.SqlBindInfo
 import com.openlattice.analysis.requests.Filter
+import com.openlattice.data.storage.partitions.getPartition
 import com.openlattice.edm.PostgresEdmTypeConverter
 import com.openlattice.edm.type.PropertyType
 import com.openlattice.postgres.*
@@ -689,15 +690,6 @@ internal val selectEntitySetTextProperties = "SELECT COALESCE(${getSourceDataCol
  */
 internal val selectEntitiesTextProperties = "$selectEntitySetTextProperties AND ${ID_VALUE.name} = ANY(?)"
 
-// Consistently Ordered, Unique Values, Constant Index
-fun getPartition(entityKeyId: UUID, partitions: List<Int>): Int {
-    return partitions[entityKeyId.leastSignificantBits.toInt() % partitions.size]
-}
-
-fun getPartition(entityKeyId: UUID, partitions: Array<Int>): Int {
-    return partitions[entityKeyId.leastSignificantBits.toInt() % partitions.size]
-}
-
 /**
  * Builds the list of partitions for a given set of entity key ids.
  * @param entityKeyIds The entity key ids whose partitions will be retrieved.
@@ -705,7 +697,11 @@ fun getPartition(entityKeyId: UUID, partitions: Array<Int>): Int {
  * @return A list of partitions.
  */
 fun getPartitionsInfo(entityKeyIds: Set<UUID>, partitions: List<Int>): List<Int> {
-    return entityKeyIds.map { entityKeyId -> getPartition(entityKeyId, partitions) }
+    return entityKeyIds.map { entityKeyId ->
+        getPartition(
+                entityKeyId, partitions
+        )
+    }
 }
 
 /**
@@ -718,7 +714,11 @@ fun getPartitionsInfo(entityKeyIds: Set<UUID>, partitions: List<Int>): List<Int>
  */
 @Deprecated("Unused")
 fun getPartitionsInfoMap(entityKeyIds: Set<UUID>, partitions: List<Int>): Map<UUID, Int> {
-    return entityKeyIds.associateWith { entityKeyId -> getPartition(entityKeyId, partitions) }
+    return entityKeyIds.associateWith { entityKeyId ->
+        getPartition(
+                entityKeyId, partitions
+        )
+    }
 }
 
 fun getMergedDataColumnName(datatype: PostgresDatatype): String {

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -697,6 +697,10 @@ fun getPartition(entityKeyId: UUID, partitions: List<Int>): Int {
     return partitions[partitionSelectorFromId(entityKeyId) % partitions.size]
 }
 
+fun getPartition(entityKeyId: UUID, partitions: Array<Int>): Int {
+    return partitions[partitionSelectorFromId(entityKeyId) % partitions.size]
+}
+
 /**
  * Builds the list of partitions for a given set of entity key ids.
  * @param entityKeyIds The entity key ids whose partitions will be retrieved.

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -695,7 +695,7 @@ fun getPartition(entityKeyId: UUID, partitions: List<Int>): Int {
 }
 
 fun getPartition(entityKeyId: UUID, partitions: Array<Int>): Int {
-    return partitions[partitionSelectorFromId(entityKeyId) % partitions.size]
+    return partitions[entityKeyId.leastSignificantBits.toInt() % partitions.size]
 }
 
 /**

--- a/src/main/kotlin/com/openlattice/data/storage/partitions/PartitionManager.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/partitions/PartitionManager.kt
@@ -132,3 +132,12 @@ private val EMPTIEST_PARTITIONS = """
             WHERE $ENTITY_SET_SIZES_VIEW.$COUNT > 0 
             AND array_length( ${PARTITIONS.name}, 1) > 0
         """.trimIndent()
+
+// Consistently Ordered, Unique Values, Constant Index
+fun getPartition(entityKeyId: UUID, partitions: List<Int>): Int {
+    return partitions[entityKeyId.leastSignificantBits.toInt() % partitions.size]
+}
+
+fun getPartition(entityKeyId: UUID, partitions: IntArray): Int {
+    return partitions[entityKeyId.leastSignificantBits.toInt() % partitions.size]
+}

--- a/src/main/kotlin/com/openlattice/graph/Graph.kt
+++ b/src/main/kotlin/com/openlattice/graph/Graph.kt
@@ -33,7 +33,7 @@ import com.openlattice.analysis.requests.*
 import com.openlattice.data.*
 import com.openlattice.data.storage.PostgresEntityDataQueryService
 import com.openlattice.data.storage.entityKeyIdColumns
-import com.openlattice.data.storage.getPartition
+import com.openlattice.data.storage.partitions.getPartition
 import com.openlattice.data.storage.partitions.PartitionManager
 import com.openlattice.data.storage.selectEntitySetWithCurrentVersionOfPropertyTypes
 import com.openlattice.datastore.services.EntitySetManager
@@ -116,7 +116,9 @@ class Graph(
     private fun addKeyIds(ps: PreparedStatement, dataEdgeKey: DataEdgeKey, startIndex: Int = 1) {
         val edk = dataEdgeKey.src
         val partitions = partitionManager.getEntitySetPartitions(edk.entitySetId)
-        val partition = getPartition(edk.entityKeyId, partitions.toList())
+        val partition = getPartition(
+                edk.entityKeyId, partitions.toList()
+        )
         ps.setObject(startIndex, partition)
         ps.setObject(startIndex + 1, dataEdgeKey.src.entityKeyId)
         ps.setObject(startIndex + 2, dataEdgeKey.dst.entityKeyId)
@@ -1406,7 +1408,9 @@ fun bindColumnsForEdge(
 
     var index = 1
 
-    ps.setObject(index++, getPartition(edk.entityKeyId, partitions))
+    ps.setObject(index++,
+                 getPartition(edk.entityKeyId, partitions)
+    )
     ps.setObject(index++, dataEdgeKey.src.entitySetId)
     ps.setObject(index++, dataEdgeKey.src.entityKeyId)
     ps.setObject(index++, dataEdgeKey.dst.entitySetId)

--- a/src/main/kotlin/com/openlattice/hazelcast/pods/HazelcastQueuePod.kt
+++ b/src/main/kotlin/com/openlattice/hazelcast/pods/HazelcastQueuePod.kt
@@ -44,7 +44,7 @@ class HazelcastQueuePod {
     @Bean
     fun idGenerationQueueConfigurer(): QueueConfigurer {
         return QueueConfigurer(HazelcastQueue.ID_GENERATION.name) { config ->
-            config.setMaxSize(HazelcastIdGenerationService.NUM_PARTITIONS * 3).backupCount = 1
+            config.setMaxSize(HazelcastIdGenerationService.NUM_PARTITIONS * 10).backupCount = 1
         }
     }
 

--- a/src/main/kotlin/com/openlattice/ids/HazelcastIdGenerationService.kt
+++ b/src/main/kotlin/com/openlattice/ids/HazelcastIdGenerationService.kt
@@ -1,34 +1,40 @@
 package com.openlattice.ids
 
 import com.geekbeast.hazelcast.HazelcastClientProvider
+import com.google.common.collect.Queues
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.openlattice.hazelcast.HazelcastClient
 import com.openlattice.hazelcast.HazelcastMap
 import com.openlattice.hazelcast.HazelcastQueue
 import org.slf4j.LoggerFactory
 import java.util.*
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.Executors
 
 /**
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
-class HazelcastIdGenerationService(clients: HazelcastClientProvider, private val executor: ListeningExecutorService) {
+class HazelcastIdGenerationService(clients: HazelcastClientProvider) {
 
     /*
      * This should be good enough until we scale past 65536 Hazelcast nodes.
      */
     companion object {
+        private const val PARTITION_SCROLL_SIZE = 5
         private const val MASK_LENGTH = 16
         const val NUM_PARTITIONS = 1 shl MASK_LENGTH //65536
         private val logger = LoggerFactory.getLogger(HazelcastIdGenerationService::class.java)
+        private val executor = Executors.newSingleThreadExecutor()
     }
 
     /*
      * Each range owns a portion of the keyspace.
      */
     private val hazelcastInstance = clients.getClient(HazelcastClient.IDS.name)
-    private val scrolls = HazelcastMap.ID_GENERATION.getMap( hazelcastInstance )
-    private val idsQueue = HazelcastQueue.ID_GENERATION.getQueue( hazelcastInstance )
+    private val scrolls = HazelcastMap.ID_GENERATION.getMap(hazelcastInstance)
+    private val idsQueue = HazelcastQueue.ID_GENERATION.getQueue(hazelcastInstance)
+    private val localQueue = Queues.newArrayBlockingQueue<UUID>(NUM_PARTITIONS) as BlockingQueue<UUID>
 
     init {
         if (scrolls.isEmpty) {
@@ -43,29 +49,34 @@ class HazelcastIdGenerationService(clients: HazelcastClientProvider, private val
                 //Use the 0 key a fence around the entire map.
                 scrolls.lock(0L)
                 //TODO: Handle exhaustion of partition.
-                scrolls.executeOnEntries(IdsGeneratingEntryProcessor(1))
+                scrolls.executeOnEntries(IdsGeneratingEntryProcessor(PARTITION_SCROLL_SIZE)) as Map<Long, List<UUID>>
             } finally {
                 scrolls.unlock(0L)
             }
 
-            ids.values
-                    .map { (it as List<UUID>)[0] }
-                    .forEach { idsQueue.put(it) }
+            ids.values.asSequence().flatten().forEach { idsQueue.put(it) }
+
             logger.info("Added $NUM_PARTITIONS ids to queue")
         }
     }
 
-    fun returnId( id: UUID ) {
-        executor.submit {
-            idsQueue.put(id)
-        }
+    /**
+     * Returns an id to the local id for later use.
+     * @param id to return to the pool
+     */
+    fun returnId(id: UUID) {
+        localQueue.offer(id)
+    }
+
+    fun returnIds(ids: Collection<UUID>) {
+        ids.forEach(::returnId)
     }
 
     fun getNextIds(count: Int): Set<UUID> {
-        return generateSequence { idsQueue.take() }.take(count).toSet()
+        return generateSequence { getNextId() }.take(count).toSet()
     }
 
     fun getNextId(): UUID {
-        return idsQueue.take()
+        return localQueue.poll() ?: idsQueue.take()
     }
 }


### PR DESCRIPTION
This reduces hazelcast pressure doing integrations, fixes uuid list serializaton during id generation, improves local queue reservoir logic, and makes more ids available for generation.

This will now leak ~325K ids every time service is restarted, so at some point we should build some service that looks for gaps in the sequence, but not a priority at the moment.