### PR TITLE
Bugfix/single transaction writes no dupe reads

### DIFF
--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -110,9 +110,9 @@ internal fun selectEntitiesGroupedByIdAndPropertyTypeId(
     //Already have the comma prefix
     val metadataOptionsSql = metadataOptions.joinToString("") { mapMetaDataToSelector(it) }
     val columnsSql = if (detailed) detailedValueColumnsSql else valuesColumnsSql
-    val idColumn = if( linking ) ORIGIN_ID.name else ID_VALUE.name
+    val idColumn = if (linking) ORIGIN_ID.name else ID_VALUE.name
     return "SELECT ${ENTITY_SET_ID.name},$idColumn as ${ID_VALUE.name},${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
-            "FROM ${DATA.name} ${optionalWhereClauses(idsPresent, partitionsPresent, entitySetsPresent)}"
+            "FROM ${DATA.name} ${optionalWhereClauses(idsPresent, partitionsPresent, entitySetsPresent, linking)}"
 }
 
 /**
@@ -144,7 +144,7 @@ private fun mapMetaDataToColumnName(metadataOption: MetadataOption): String {
 private fun mapMetaDataToSelector(metadataOption: MetadataOption): String {
     return when (metadataOption) {
         MetadataOption.LAST_WRITE -> ",max(${LAST_WRITE.name}) AS ${mapMetaDataToColumnName(metadataOption)}"
-        MetadataOption.ENTITY_KEY_IDS -> "${ID_VALUE.name} as ${ORIGIN_ID.name}" //Adapter for queries for now.
+        MetadataOption.ENTITY_KEY_IDS -> ",${ID_VALUE.name} as ${ORIGIN_ID.name}" //Adapter for queries for now.
         else -> throw UnsupportedOperationException("No implementation yet for metadata option $metadataOption")
     }
 }
@@ -252,10 +252,12 @@ internal fun groupBy(columns: String): String {
 fun optionalWhereClauses(
         idsPresent: Boolean = true,
         partitionsPresent: Boolean = true,
-        entitySetsPresent: Boolean = true
+        entitySetsPresent: Boolean = true,
+        linking: Boolean = false
 ): String {
     val entitySetClause = if (entitySetsPresent) "${ENTITY_SET_ID.name} = ANY(?)" else ""
-    val idsClause = if (idsPresent) "${ID_VALUE.name} = ANY(?)" else ""
+    val idsColumn = if (linking) ORIGIN_ID.name else ID_VALUE.name
+    val idsClause = if (idsPresent) "$idsColumn = ANY(?)" else ""
     val partitionClause = if (partitionsPresent) "${PARTITION.name} = ANY(?)" else ""
     val versionsClause = "${VERSION.name} > 0 "
 

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -103,12 +103,14 @@ internal fun selectEntitiesGroupedByIdAndPropertyTypeId(
         idsPresent: Boolean = true,
         partitionsPresent: Boolean = true,
         entitySetsPresent: Boolean = true,
-        detailed: Boolean = false
+        detailed: Boolean = false,
+        linking: Boolean = true
 ): String {
     //Already have the comma prefix
     val metadataOptionsSql = metadataOptions.joinToString("") { mapMetaDataToSelector(it) }
     val columnsSql = if (detailed) detailedValueColumnsSql else valuesColumnsSql
-    return "SELECT ${ENTITY_SET_ID.name},${ID_VALUE.name},${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
+    val idColumn = if (linking) ORIGIN_ID.name else ID_VALUE.name
+    return "SELECT ${ENTITY_SET_ID.name},$idColumn,${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
             "FROM ${DATA.name} ${optionalWhereClauses(idsPresent, partitionsPresent, entitySetsPresent)}"
 }
 
@@ -230,7 +232,9 @@ internal fun doBind(ps: PreparedStatement, info: SqlBindInfo) {
 }
 
 internal val ESID_EKID_PART = "${ENTITY_SET_ID.name},${ID_VALUE.name},${PARTITION.name}"
+internal val ESID_LID_PART = "${ENTITY_SET_ID.name},${ORIGIN_ID.name},${PARTITION.name}"
 internal val ESID_EKID_PART_PTID = "${ENTITY_SET_ID.name},${ID_VALUE.name}, ${PARTITION.name},${PROPERTY_TYPE_ID.name}"
+internal val ESID_LID_PART_PTID = "${ENTITY_SET_ID.name},${ORIGIN_ID.name}, ${PARTITION.name},${PROPERTY_TYPE_ID.name}"
 
 internal fun groupBy(columns: String): String {
     return "GROUP BY ($columns)"

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -104,8 +104,7 @@ internal fun selectEntitiesGroupedByIdAndPropertyTypeId(
         idsPresent: Boolean = true,
         partitionsPresent: Boolean = true,
         entitySetsPresent: Boolean = true,
-        detailed: Boolean = false,
-        linking: Boolean = false
+        detailed: Boolean = false
 ): String {
     //Already have the comma prefix
     val metadataOptionsSql = metadataOptions.joinToString("") { mapMetaDataToSelector(it) }
@@ -232,9 +231,7 @@ internal fun doBind(ps: PreparedStatement, info: SqlBindInfo) {
 }
 
 internal val ESID_EKID_PART = "${ENTITY_SET_ID.name},${ID_VALUE.name},${PARTITION.name}"
-internal val ESID_LID_PART = "${ENTITY_SET_ID.name},${ORIGIN_ID.name},${PARTITION.name}"
 internal val ESID_EKID_PART_PTID = "${ENTITY_SET_ID.name},${ID_VALUE.name}, ${PARTITION.name},${PROPERTY_TYPE_ID.name}"
-internal val ESID_LID_PART_PTID = "${ENTITY_SET_ID.name},${ORIGIN_ID.name}, ${PARTITION.name},${PROPERTY_TYPE_ID.name}"
 
 internal fun groupBy(columns: String): String {
     return "GROUP BY ($columns)"

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -352,7 +352,7 @@ fun buildUpsertEntitiesAndLinkedData(): String {
  *
  * 1 - entity set id
  *
- * 2 - entity key ids
+ * 2 - entity key id
  *
  * 3 - partition
  */
@@ -360,6 +360,24 @@ val lockEntitiesInIdsTable =
         "SELECT 1 FROM ${IDS.name} " +
                 "WHERE ${ENTITY_SET_ID.name} = ? AND ${ID_VALUE.name} = ? AND ${PARTITION.name} = ? " +
                 "FOR UPDATE"
+
+/**
+ * Preparable sql to lock entities in [IDS] table.
+ *
+ * This query will lock provided entities that have an assigned linking id in ID order.
+ *
+ * The bind order is the following:
+ *
+ * 1 - entity key ids
+ *
+ * 2 - partition
+ */
+val bulkLockEntitiesInIdsTable =
+        "SELECT 1 FROM ${IDS.name} " +
+                "WHERE ${ID_VALUE.name} = ANY(?) AND ${PARTITION.name} = ? " +
+                "ORDER BY ${ID_VALUE.name}" +
+                "FOR UPDATE"
+
 
 /**
  * Preparable sql to lock entities in [IDS] table.

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -88,7 +88,8 @@ fun buildPreparableFiltersSql(
             metadataOptions,
             idsPresent = idsPresent,
             partitionsPresent = partitionsPresent,
-            detailed = detailed
+            detailed = detailed,
+            linking = linking
     ) + linkingClause + filtersClause + innerGroupBy
 
     val sql = "SELECT ${ENTITY_SET_ID.name},${ID_VALUE.name},${PARTITION.name}$metadataOptionColumnsSql," +
@@ -104,13 +105,12 @@ internal fun selectEntitiesGroupedByIdAndPropertyTypeId(
         partitionsPresent: Boolean = true,
         entitySetsPresent: Boolean = true,
         detailed: Boolean = false,
-        linking: Boolean = true
+        linking: Boolean = false
 ): String {
     //Already have the comma prefix
     val metadataOptionsSql = metadataOptions.joinToString("") { mapMetaDataToSelector(it) }
     val columnsSql = if (detailed) detailedValueColumnsSql else valuesColumnsSql
-    val idColumn = if (linking) ORIGIN_ID.name else ID_VALUE.name
-    return "SELECT ${ENTITY_SET_ID.name},$idColumn,${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
+    return "SELECT ${ENTITY_SET_ID.name},${ID_VALUE.name},${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
             "FROM ${DATA.name} ${optionalWhereClauses(idsPresent, partitionsPresent, entitySetsPresent)}"
 }
 
@@ -143,7 +143,7 @@ private fun mapMetaDataToColumnName(metadataOption: MetadataOption): String {
 private fun mapMetaDataToSelector(metadataOption: MetadataOption): String {
     return when (metadataOption) {
         MetadataOption.LAST_WRITE -> ",max(${LAST_WRITE.name}) AS ${mapMetaDataToColumnName(metadataOption)}"
-        MetadataOption.ENTITY_KEY_IDS -> ",${ORIGIN_ID.name}"
+        MetadataOption.ENTITY_KEY_IDS -> ",${ID_VALUE.name} as ${ORIGIN_ID.name}" //Adapter for queries for now.
         else -> throw UnsupportedOperationException("No implementation yet for metadata option $metadataOption")
     }
 }

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresDataQueries.kt
@@ -104,12 +104,14 @@ internal fun selectEntitiesGroupedByIdAndPropertyTypeId(
         idsPresent: Boolean = true,
         partitionsPresent: Boolean = true,
         entitySetsPresent: Boolean = true,
-        detailed: Boolean = false
+        detailed: Boolean = false,
+        linking: Boolean = false
 ): String {
     //Already have the comma prefix
     val metadataOptionsSql = metadataOptions.joinToString("") { mapMetaDataToSelector(it) }
     val columnsSql = if (detailed) detailedValueColumnsSql else valuesColumnsSql
-    return "SELECT ${ENTITY_SET_ID.name},${ID_VALUE.name},${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
+    val idColumn = if( linking ) ORIGIN_ID.name else ID_VALUE.name
+    return "SELECT ${ENTITY_SET_ID.name},$idColumn as ${ID_VALUE.name},${PARTITION.name},${PROPERTY_TYPE_ID.name}$metadataOptionsSql,$columnsSql " +
             "FROM ${DATA.name} ${optionalWhereClauses(idsPresent, partitionsPresent, entitySetsPresent)}"
 }
 
@@ -142,7 +144,7 @@ private fun mapMetaDataToColumnName(metadataOption: MetadataOption): String {
 private fun mapMetaDataToSelector(metadataOption: MetadataOption): String {
     return when (metadataOption) {
         MetadataOption.LAST_WRITE -> ",max(${LAST_WRITE.name}) AS ${mapMetaDataToColumnName(metadataOption)}"
-        MetadataOption.ENTITY_KEY_IDS -> ",${ID_VALUE.name} as ${ORIGIN_ID.name}" //Adapter for queries for now.
+        MetadataOption.ENTITY_KEY_IDS -> "${ID_VALUE.name} as ${ORIGIN_ID.name}" //Adapter for queries for now.
         else -> throw UnsupportedOperationException("No implementation yet for metadata option $metadataOption")
     }
 }

--- a/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
+++ b/src/main/kotlin/com/openlattice/data/storage/PostgresEntityDataQueryService.kt
@@ -315,7 +315,7 @@ class PostgresEntityDataQueryService(
      */
     private fun upsertEntities(
             entitySetId: UUID,
-            tombstoneFn: (connection: Connection, version: Long, entityBatch: Map<UUID, Map<UUID, Set<Any>>>) -> Unit,
+            tombstoneFn: (version: Long, entityBatch: Map<UUID, Map<UUID, Set<Any>>>) -> Unit,
             entities: Map<UUID, Map<UUID, Set<Any>>>, // ekids ->
             authorizedPropertyTypes: Map<UUID, PropertyType>,
             version: Long,
@@ -373,13 +373,13 @@ class PostgresEntityDataQueryService(
     ): Int {
         return hds.connection.use { connection ->
             //Update the versions of all entities.
-            val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entities.keys)
             val versionsArrays = PostgresArrays.createLongArray(connection, version)
 
             /*
-             * We do not need entity level locking as our version field ensures that data is consistent even across
-             * transactions in all cases, except deletes (clear is fine) as long entity version is not bumped until
-             * all properties are written.
+             * We do not need entity level locking as the version in the ids table ensures that data is consistent even
+             * if the follow property upserts fails halfway through.
+             *
+             * Previous me said deletes had to be handled specially, but it makes sense that clear is fine.
              *
              */
 
@@ -415,41 +415,46 @@ class PostgresEntityDataQueryService(
                 upsertPropertyValues.values.map { it.executeBatch().sum() }.sum()
             }.sum()
 
+            /**
+             * At this point, we either need to either commit all versions by updating the version in the ids table our
+             * fail out. Dead locks should be impossible due to explicit locking within the transaction.
+             *
+             * TODO: Switch back to the single SELECT FOR UPDATE statement instead of sequence of statements for perf
+             * reasons.
+             */
+
             connection.autoCommit = false
+            val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entities.keys)
             val lockEntities = connection.prepareStatement(lockEntitiesInIdsTable)
             //Make data visible by marking new version in ids table.
             val upsertEntities = connection.prepareStatement(buildUpsertEntitiesAndLinkedData())
-
-            val updatedLinkedEntities = attempt(LinearBackoff(60000, 125), 32) {
-                try {
-                    entities.keys.sorted().forEach { id ->
-                        lockEntities.setObject(1, entitySetId)
-                        lockEntities.setObject(2, id)
-                        lockEntities.setInt(3, partition)
-                        lockEntities.execute()
-                    }
-
-                    upsertEntities.setObject(1, versionsArrays)
-                    upsertEntities.setObject(2, version)
-                    upsertEntities.setObject(3, version)
-                    upsertEntities.setObject(4, entitySetId)
-                    upsertEntities.setArray(5, entityKeyIdsArr)
-                    upsertEntities.setInt(6, partition)
-                    upsertEntities.setInt(7, partition)
-                    upsertEntities.setLong(8, version)
-                    val updatedCount = upsertEntities.executeUpdate()
-                    connection.commit()
-                    updatedCount
-                } catch (ex: PSQLException) {
-                    //Should be pretty rare.
-                    connection.rollback()
-                    throw ex
+            val updatedLinkedEntities = try {
+                entities.keys.sorted().forEach { id ->
+                    lockEntities.setObject(1, entitySetId)
+                    lockEntities.setObject(2, id)
+                    lockEntities.setInt(3, partition)
+                    lockEntities.execute()
                 }
+
+                upsertEntities.setObject(1, versionsArrays)
+                upsertEntities.setObject(2, version)
+                upsertEntities.setObject(3, version)
+                upsertEntities.setObject(4, entitySetId)
+                upsertEntities.setArray(5, entityKeyIdsArr)
+                upsertEntities.setInt(6, partition)
+                upsertEntities.setInt(7, partition)
+                upsertEntities.setLong(8, version)
+                val updatedCount = upsertEntities.executeUpdate()
+                connection.commit()
+                updatedCount
+            } catch (ex: PSQLException) {
+                //Should be pretty rare.
+                connection.rollback()
+                throw ex
             }
-            
             connection.autoCommit = true
             logger.debug("Updated $updatedLinkedEntities linked entities as part of insert.")
-            updatedPropertyCounts
+            return updatedPropertyCounts
         }
 
     }
@@ -648,16 +653,16 @@ class PostgresEntityDataQueryService(
 
         val version = System.currentTimeMillis()
 
-        return hds.connection.use { conn ->
-            tombstone(
-                    entitySetId,
-                    entityKeyIds,
-                    authorizedPropertyTypes.values,
-                    version,
-                    partitions
-            )
-            tombstoneIdsTable(conn, entitySetId, entityKeyIds, version, partitions)
-        }
+
+        tombstone(
+                entitySetId,
+                entityKeyIds,
+                authorizedPropertyTypes.values,
+                version,
+                partitions
+        )
+        return tombstoneIdsTable(entitySetId, entityKeyIds, version, partitions)
+
     }
 
     /**
@@ -978,31 +983,39 @@ class PostgresEntityDataQueryService(
      * @param partitions Contains the partition information for the requested entity set.
      */
     private fun tombstoneIdsTable(
-            conn: Connection,
             entitySetId: UUID,
             entityKeyIds: Set<UUID>,
             version: Long,
             partitions: List<Int> = partitionManager.getEntitySetPartitions(entitySetId).toList()
     ): WriteEvent {
-        val entityKeyIdsArr = PostgresArrays.createUuidArray(conn, entityKeyIds)
+        return hds.connection.use { conn ->
+            conn.autoCommit = false
+            val partitionsMap = entityKeyIds.groupBy { getPartition(it, partitions) }
 
-        val partitionsArr = PostgresArrays.createIntArray(conn, entityKeyIds.map {
-            getPartition(
-                    it, partitions
-            )
-        })
+            val lockedEntities = conn.prepareStatement(bulkLockEntitiesInIdsTable)
 
-        val numUpdated = conn.prepareStatement(updateVersionsForEntitiesInEntitySet).use { ps ->
-            ps.setLong(1, -version)
-            ps.setLong(2, -version)
-            ps.setLong(3, -version)
-            ps.setObject(4, entitySetId)
-            ps.setArray(5, entityKeyIdsArr)
-            ps.setArray(6, partitionsArr)
-            ps.executeUpdate()
+            partitionsMap.forEach { (partition, ids) ->
+                lockedEntities.setArray(2, PostgresArrays.createUuidArray(conn, ids))
+                lockedEntities.setInt(3, partition)
+                lockedEntities.addBatch()
+            }
+            lockedEntities.executeBatch()
+
+            val entityKeyIdsArr = PostgresArrays.createUuidArray(conn, entityKeyIds)
+            val partitionsArr = PostgresArrays.createIntArray(conn, partitionsMap.keys)
+
+            val numUpdated = conn.prepareStatement(updateVersionsForEntitiesInEntitySet).use { ps ->
+                ps.setLong(1, -version)
+                ps.setLong(2, -version)
+                ps.setLong(3, -version)
+                ps.setObject(4, entitySetId)
+                ps.setArray(5, entityKeyIdsArr)
+                ps.setArray(6, partitionsArr)
+                ps.executeUpdate()
+            }
+
+            WriteEvent(version, numUpdated)
         }
-
-        return WriteEvent(version, numUpdated)
     }
 
     /**
@@ -1036,7 +1049,9 @@ class PostgresEntityDataQueryService(
                 )
             })
 
-            val numUpdated = conn.prepareStatement(updateVersionsForPropertyTypesInEntitiesInEntitySet()).use { ps ->
+            val numUpdated = conn.prepareStatement(
+                    updateVersionsForPropertyTypesInEntitiesInEntitySet()
+            ).use { ps ->
                 ps.setLong(1, -version)
                 ps.setLong(2, -version)
                 ps.setLong(3, -version)

--- a/src/test/kotlin/com/openlattice/data/PostgresEntityDataQueryServiceTest.kt
+++ b/src/test/kotlin/com/openlattice/data/PostgresEntityDataQueryServiceTest.kt
@@ -86,7 +86,7 @@ class PostgresEntityDataQueryServiceTest {
                         propertyTypes.associateBy { it.id },
                         mapOf(),
                         EnumSet.of(MetadataOption.ENTITY_KEY_IDS),
-                        linking = false,
+                        linking = true,
                         idsPresent = true,
                         partitionsPresent = true
                 ).first


### PR DESCRIPTION
This adds locking to clear entities and switches to a more efficient way of reading linked entities.

This will remove the need for us to do an extra write for linked entities after each write and should have a pretty big positive performance impact. 

We will need to run a migration to set ORIGIN_ID to LINKING_ID (and it's probably worth looking at renaming the column). The migration should be fairly efficient since we do equality on the partitions column allowing the query to be pushed down to all nodes.

@makosblade This will require modifying linking queries to just do updates instead of inserts (should be way more efficient).