### PR TITLE
Fixes auth0 deletion routine.

### DIFF
--- a/src/main/java/com/openlattice/organizations/processors/OrganizationEntryProcessor.kt
+++ b/src/main/java/com/openlattice/organizations/processors/OrganizationEntryProcessor.kt
@@ -29,7 +29,7 @@ class OrganizationEntryProcessor(
         }
         return null
     }
-    data class Result( val value: Any?, val modified: Boolean = true )
+    data class Result( val value: Any? , val modified: Boolean = true )
 }
 
 


### PR DESCRIPTION
The organization service now exposes an API call to remove a principal from every organization they belong to. By default it clears permissions, so that it can be used to "reset" a user account. It also possible to not do the extra work of clearing permissions, when the caller is going to implement their own permission handling upon removal.
